### PR TITLE
Support reading a file to pyarrow table in catalog import

### DIFF
--- a/src/hipscat_import/catalog/file_readers.py
+++ b/src/hipscat_import/catalog/file_readers.py
@@ -4,7 +4,7 @@ import abc
 from typing import Any, Dict, Union
 
 import pandas as pd
-import pyarrow
+import pyarrow as pa
 import pyarrow.dataset
 import pyarrow.parquet as pq
 from astropy.io import ascii as ascii_reader
@@ -355,6 +355,32 @@ class ParquetReader(InputReader):
             batch_size=self.chunksize, columns=columns, use_pandas_metadata=True
         ):
             yield smaller_table.to_pandas()
+
+
+class ParquetPyarrowReader(InputReader):
+    """Parquet reader for the most common Parquet reading arguments.
+
+    Attributes:
+        chunksize (int): number of rows of the file to process at once.
+            For large files, this can prevent loading the entire file
+            into memory at once.
+        column_names (list[str] or None): Names of columns to use from the input dataset.
+            If None, use all columns.
+        kwargs: arguments to pass along to pyarrow.parquet.ParquetFile.
+            See https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetFile.html
+    """
+
+    def __init__(self, chunksize=500_000, column_names=None, **kwargs):
+        self.chunksize = chunksize
+        self.column_names = column_names
+        self.kwargs = kwargs
+
+    def read(self, input_file, read_columns=None):
+        self.regular_file_exists(input_file, **self.kwargs)
+        columns = read_columns or self.column_names
+        parquet_file = pq.ParquetFile(input_file, **self.kwargs)
+        for smaller_table in parquet_file.iter_batches(batch_size=self.chunksize, columns=columns):
+            yield pa.Table.from_batches([smaller_table])
 
 
 class IndexedParquetReader(InputReader):

--- a/src/hipscat_import/index/map_reduce.py
+++ b/src/hipscat_import/index/map_reduce.py
@@ -17,8 +17,9 @@ def read_leaf_file(input_file, include_columns, include_hipscat_index, drop_dupl
         schema=schema,
     )
 
-    data = data.reset_index()
-    if not include_hipscat_index:
+    if data.index.name == HIPSCAT_ID_COLUMN:
+        data = data.reset_index()
+    if not include_hipscat_index and HIPSCAT_ID_COLUMN in data.columns:
         data = data.drop(columns=[HIPSCAT_ID_COLUMN])
 
     if drop_duplicates:
@@ -32,6 +33,8 @@ def create_index(args, client):
     include_columns = [args.indexing_column]
     if args.extra_columns:
         include_columns.extend(args.extra_columns)
+    if args.include_hipscat_index:
+        include_columns.append(HIPSCAT_ID_COLUMN)
     if args.include_order_pixel:
         include_columns.extend(["Norder", "Dir", "Npix"])
 

--- a/tests/hipscat_import/catalog/test_map_reduce.py
+++ b/tests/hipscat_import/catalog/test_map_reduce.py
@@ -353,10 +353,9 @@ def test_reduce_hipscat_index(parquet_shards_dir, assert_parquet_file_ids, tmp_p
     expected_ids = [*range(700, 831)]
     assert_parquet_file_ids(output_file, "id", expected_ids)
     data_frame = pd.read_parquet(output_file, engine="pyarrow")
-    assert data_frame.index.name == "_hipscat_index"
     npt.assert_array_equal(
         data_frame.columns,
-        ["id", "ra", "dec", "ra_error", "dec_error", "Norder", "Dir", "Npix"],
+        ["_hipscat_index", "id", "ra", "dec", "ra_error", "dec_error", "Norder", "Dir", "Npix"],
     )
 
     mr.reduce_pixel_shards(

--- a/tests/hipscat_import/catalog/test_run_import.py
+++ b/tests/hipscat_import/catalog/test_run_import.py
@@ -279,6 +279,7 @@ def test_dask_runner(
     # Check that the schema is correct for leaf parquet and _metadata files
     expected_parquet_schema = pa.schema(
         [
+            pa.field("_hipscat_index", pa.uint64()),
             pa.field("id", pa.int64()),
             pa.field("ra", pa.float32()),
             pa.field("dec", pa.float32()),
@@ -287,30 +288,12 @@ def test_dask_runner(
             pa.field("Norder", pa.uint8()),
             pa.field("Dir", pa.uint64()),
             pa.field("Npix", pa.uint64()),
-            pa.field("_hipscat_index", pa.uint64()),
         ]
     )
     schema = pq.read_metadata(output_file).schema.to_arrow_schema()
     assert schema.equals(expected_parquet_schema, check_metadata=False)
     schema = pq.read_metadata(os.path.join(args.catalog_path, "_metadata")).schema.to_arrow_schema()
     assert schema.equals(expected_parquet_schema, check_metadata=False)
-
-    # Check that, when re-loaded as a pandas dataframe, the appropriate numeric types are used.
-    data_frame = pd.read_parquet(output_file, engine="pyarrow")
-    expected_dtypes = pd.Series(
-        {
-            "id": np.int64,
-            "ra": np.float32,
-            "dec": np.float32,
-            "ra_error": np.float32,
-            "dec_error": np.float32,
-            "Norder": np.uint8,
-            "Dir": np.uint64,
-            "Npix": np.uint64,
-        }
-    )
-    assert data_frame.dtypes.equals(expected_dtypes)
-    assert data_frame.index.dtype == np.uint64
 
 
 @pytest.mark.dask

--- a/tests/hipscat_import/catalog/test_run_round_trip.py
+++ b/tests/hipscat_import/catalog/test_run_round_trip.py
@@ -496,7 +496,7 @@ class PyarrowCsvReader(CsvReader):
         table = csv.read_csv(input_file)
         extras = pa.array([[True, False, True]] * len(table), type=pa.list_(pa.bool_(), 3))
         table = table.append_column("extras", extras)
-        yield table.to_pandas()
+        yield table.to_pandas(types_mapper=pd.ArrowDtype)
 
 
 @pytest.mark.dask


### PR DESCRIPTION
## Change Description

This is related to issue #351, but does not close it.

Allows the InputReader read method to return a pyarrow Table, instead of a Pandas dataframe. Pandas dataframes are converted to pyarrow tables, and all manipulation after that point is based on pyarrow operations. 

This means that tables generated will NOT have the `_hipscat_index` field set as the pandas index. This PR should not be merged until LSDB can support these tables, via fixing https://github.com/astronomy-commons/lsdb/issues/67