### PR TITLE
Remove locally-created package before publishing.

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -32,13 +32,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install .
     - name: Create lock requirements file
-      run: pip list --format=freeze --exclude "hats-import" > requirements.txt
-    - name: Install dev dependencies
-      run: pip install .[dev]
-    - name: Run unit tests with pytest
-      run: python -m pytest tests
-    - name: Run dask-on-ray tests with pytest
-      run: python -m pytest tests --use_ray
+      run: |
+        pip list --format=freeze --exclude "hats-import" > requirements.txt
+        pip uninstall -y hats-import
     - name: Install build tools
       run: pip install build
     - name: Build package


### PR DESCRIPTION
## Change Description

See action failure: https://github.com/astronomy-commons/hats-import/actions/runs/11386003133

We're unable to publish to pypi because we `pip install` the package locally. We do this in order to resolve dependencies and create a requirements.txt file.

This attempts a work-around to generate the requirements file, and remove the locally built package.