### PR TITLE
Remove pandas metadata in hipscat conversion

### DIFF
--- a/src/hats_import/hipscat_conversion/run_conversion.py
+++ b/src/hats_import/hipscat_conversion/run_conversion.py
@@ -141,7 +141,7 @@ def _convert_partition_file(pixel, args, schema, ra_column, dec_column):
             .append_column("Dir", [np.full(num_rows, fill_value=pixel.dir, dtype=np.int64)])
             .append_column("Npix", [np.full(num_rows, fill_value=pixel.pixel, dtype=np.int64)])
         )
-        table.schema = table.schema.remove_metadata()
+        table = table.replace_schema_metadata()
 
         destination_file = paths.pixel_catalog_file(args.catalog_path, pixel)
         destination_file.parent.mkdir(parents=True, exist_ok=True)
@@ -152,6 +152,7 @@ def _convert_partition_file(pixel, args, schema, ra_column, dec_column):
         except Exception:  # pylint: disable=broad-exception-caught
             pass
         dask_print(exception)
+        raise exception
 
 
 def _write_nested_fits_map(input_dir, output_dir):

--- a/src/hats_import/hipscat_conversion/run_conversion.py
+++ b/src/hats_import/hipscat_conversion/run_conversion.py
@@ -141,6 +141,7 @@ def _convert_partition_file(pixel, args, schema, ra_column, dec_column):
             .append_column("Dir", [np.full(num_rows, fill_value=pixel.dir, dtype=np.int64)])
             .append_column("Npix", [np.full(num_rows, fill_value=pixel.pixel, dtype=np.int64)])
         )
+        table.schema = table.schema.remove_metadata()
 
         destination_file = paths.pixel_catalog_file(args.catalog_path, pixel)
         destination_file.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/hats_import/hipscat_conversion/test_run_conversion.py
+++ b/tests/hats_import/hipscat_conversion/test_run_conversion.py
@@ -8,6 +8,7 @@ import pytest
 
 import hats_import.hipscat_conversion.run_conversion as runner
 from hats_import.hipscat_conversion.arguments import ConversionArguments
+from hats.io.file_io import file_io
 
 
 def test_empty_args():
@@ -74,6 +75,12 @@ def test_run_conversion_object(
     assert schema.equals(expected_parquet_schema, check_metadata=False)
     schema = pq.read_metadata(args.catalog_path / "dataset" / "_common_metadata").schema.to_arrow_schema()
     assert schema.equals(expected_parquet_schema, check_metadata=False)
+
+    data = file_io.read_parquet_file_to_pandas(
+        output_file,
+        columns=["id" , "ra", "dec"],
+        engine="pyarrow",
+    )
 
 
 @pytest.mark.dask

--- a/tests/hats_import/hipscat_conversion/test_run_conversion.py
+++ b/tests/hats_import/hipscat_conversion/test_run_conversion.py
@@ -71,14 +71,17 @@ def test_run_conversion_object(
     )
     schema = pq.read_metadata(output_file).schema.to_arrow_schema()
     assert schema.equals(expected_parquet_schema, check_metadata=False)
+    assert schema.metadata is None
     schema = pq.read_metadata(args.catalog_path / "dataset" / "_metadata").schema.to_arrow_schema()
     assert schema.equals(expected_parquet_schema, check_metadata=False)
+    assert schema.metadata is None
     schema = pq.read_metadata(args.catalog_path / "dataset" / "_common_metadata").schema.to_arrow_schema()
     assert schema.equals(expected_parquet_schema, check_metadata=False)
+    assert schema.metadata is None
 
     data = file_io.read_parquet_file_to_pandas(
         output_file,
-        columns=["id" , "ra", "dec"],
+        columns=["id", "ra", "dec"],
         engine="pyarrow",
     )
 
@@ -125,7 +128,10 @@ def test_run_conversion_source(
     ]
     schema = pq.read_metadata(output_file).schema
     npt.assert_array_equal(schema.names, source_columns)
+    assert schema.to_arrow_schema().metadata is None
     schema = pq.read_metadata(args.catalog_path / "dataset" / "_metadata").schema
     npt.assert_array_equal(schema.names, source_columns)
+    assert schema.to_arrow_schema().metadata is None
     schema = pq.read_metadata(args.catalog_path / "dataset" / "_common_metadata").schema
     npt.assert_array_equal(schema.names, source_columns)
+    assert schema.to_arrow_schema().metadata is None

--- a/tests/hats_import/hipscat_conversion/test_run_conversion.py
+++ b/tests/hats_import/hipscat_conversion/test_run_conversion.py
@@ -5,10 +5,10 @@ import numpy.testing as npt
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+from hats.io.file_io import file_io
 
 import hats_import.hipscat_conversion.run_conversion as runner
 from hats_import.hipscat_conversion.arguments import ConversionArguments
-from hats.io.file_io import file_io
 
 
 def test_empty_args():
@@ -81,9 +81,11 @@ def test_run_conversion_object(
 
     data = file_io.read_parquet_file_to_pandas(
         output_file,
-        columns=["id", "ra", "dec"],
+        columns=["id", "ra", "dec", "_healpix_29"],
         engine="pyarrow",
     )
+    assert "_healpix_29" in data.columns
+    assert data.index.name is None
 
 
 @pytest.mark.dask


### PR DESCRIPTION
## Change Description

Pandas metadata uses the old `_hipscat_id` field. Instead of manipulating the pandas metadata to fit new columns, just remove from the parquet schema.