### PR TITLE
Update dependencies

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,18 @@ need to install or upgrade versions of dependencies to work with hats-import.
     pip install hats-import
 
 .. tip::
+    Installing optional dependencies
+
+    There are some extra dependencies that can make running hats-import in a jupyter
+    environment easier, or connecting to a variety of remote file systems.
+
+    These can be installed with the ``full`` extra.
+
+    .. code-block:: console
+
+        >> pip install hats-import[full]
+
+.. tip::
     Installing on Mac
 
     ``healpy`` is a very necessary dependency for hats libraries at this time, but
@@ -25,6 +37,8 @@ need to install or upgrade versions of dependencies to work with hats-import.
 
         >> conda config --append channels conda-forge
         >> conda install healpy
+
+
 
 Setting up a pipeline
 -------------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,9 @@ dependencies = [
     "dask[complete]>=2024.3.0", # Includes dask expressions.
     "deprecated",
     "hats >=0.4",
-    "ipykernel", # Support for Jupyter notebooks
     "numpy",
     "pandas",
     "pyarrow",
-    "pyyaml",
-    "scipy",
     "tqdm",
     "universal_pathlib",
 ]
@@ -41,7 +38,11 @@ dev = [
     "pytest-cov",
     "pytest-timeout",
     "ray", # Used for dask-on-ray testing.
-    "types-PyYAML", # type stubs for pyyaml
+]
+extra = [
+    "fsspec[full]", # complete file system specs.
+    "ipykernel", # Support for Jupyter notebooks
+    "ipywidgets", # useful for tqdm in notebooks.
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dynamic = ["version"]
 dependencies = [
     "dask[complete]>=2024.3.0", # Includes dask expressions.
     "deprecated",
-    "hats >=0.4",
+    "hats >=0.4.2",
     "numpy",
     "pandas",
     "pyarrow",
@@ -39,7 +39,7 @@ dev = [
     "pytest-timeout",
     "ray", # Used for dask-on-ray testing.
 ]
-extra = [
+full = [
     "fsspec[full]", # complete file system specs.
     "ipykernel", # Support for Jupyter notebooks
     "ipywidgets", # useful for tqdm in notebooks.


### PR DESCRIPTION
- pyyaml was unused
- scipy is no longer a direct dependency (https://github.com/astronomy-commons/hats-import/pull/405)
- ipykernel is a nice-to-have dependency for folks running inside a jupyter notebook
- but ipywidgets is an even-nicer-to-have dependency
- extras handles the nice-to-haves, including the full suite of fsspec implementations.