### PR TITLE
Constrain Dask version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "dask[complete]>=2024.3.0, <2024.11.0", # Includes dask expressions.
+    "dask[complete]>=2024.3.0", # Includes dask expressions.
     "deprecated",
     "hats >=0.4.2",
     "numpy",
@@ -28,6 +28,7 @@ dependencies = [
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)
 [project.optional-dependencies]
 dev = [
+    "dask[complete]<2024.11.0",
     "asv==0.6.4", # Used to compute performance benchmarks
     "black", # Used for static linting of files
     "jupyter", # Clears output from Jupyter notebooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "dask[complete]>=2024.3.0", # Includes dask expressions.
+    "dask[complete]>=2024.3.0, <2024.11.0", # Includes dask expressions.
     "deprecated",
     "hats >=0.4.2",
     "numpy",


### PR DESCRIPTION
Constrains Dask to version `<2024.11.0` because of issue reported in https://github.com/ray-project/ray/issues/48689.
