### PR TITLE
Remove default healpy dependency.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,8 @@ need to install or upgrade versions of dependencies to work with hats-import.
 .. tip::
     Installing on Mac
 
-    ``healpy`` is a very necessary dependency for hats libraries at this time, but
+    ``healpy`` is an optional dependency for hats-import (included in the ``full`` extra)
+    to support converting from older HiPSCat catalogs, but
     native prebuilt binaries for healpy on Apple Silicon Macs 
     `do not yet exist <https://healpy.readthedocs.io/en/latest/install.html#binary-installation-with-pip-recommended-for-most-other-python-users>`_, 
     so it's recommended to install via conda before proceeding to hats-import.

--- a/src/hats_import/hipscat_conversion/run_conversion.py
+++ b/src/hats_import/hipscat_conversion/run_conversion.py
@@ -5,7 +5,6 @@ import tempfile
 from typing import no_type_check
 
 import hats.pixel_math.healpix_shim as healpix
-import healpy as hp
 import numpy as np
 import pyarrow.parquet as pq
 from dask.distributed import as_completed, get_worker
@@ -155,6 +154,8 @@ def _convert_partition_file(pixel, args, schema, ra_column, dec_column):
 
 
 def _write_nested_fits_map(input_dir, output_dir):
+    import healpy as hp
+
     input_file = input_dir / "point_map.fits"
     if not input_file.exists():
         return

--- a/tests/hats_import/hipscat_conversion/test_run_conversion.py
+++ b/tests/hats_import/hipscat_conversion/test_run_conversion.py
@@ -24,6 +24,15 @@ def test_bad_args():
         runner.run(args, None)
 
 
+try:
+    import healpy as hp
+
+    have_healpy = True
+except ImportError:
+    have_healpy = False
+
+
+@pytest.mark.skipif(not have_healpy, reason="healpy is not installed")
 @pytest.mark.dask
 def test_run_conversion_object(
     test_data_dir,
@@ -88,6 +97,7 @@ def test_run_conversion_object(
     assert data.index.name is None
 
 
+@pytest.mark.skipif(not have_healpy, reason="healpy is not installed")
 @pytest.mark.dask
 def test_run_conversion_source(
     test_data_dir,


### PR DESCRIPTION
See https://github.com/astronomy-commons/hats/pull/433

We still need the `healpy` library to occasionally read older FITS files that may have been written in RING pixelization. Marked as optional dependency, and tests can still run against it if healpy is installed.