### PR TITLE
Force re-creation of margin catalog.

### DIFF
--- a/src/hats_import/hipscat_conversion/run_conversion.py
+++ b/src/hats_import/hipscat_conversion/run_conversion.py
@@ -38,10 +38,12 @@ def run(args: ConversionArguments, client):
     if catalog_type not in (
         CatalogType.OBJECT,
         CatalogType.SOURCE,
-        CatalogType.MARGIN,
         CatalogType.ASSOCIATION,
     ):
-        raise ValueError("Conversion only implemented for object, source, margin, and association tables")
+        raise ValueError(
+            "Conversion only implemented for object, source, and association tables. "
+            "Other tables should be re-generated."
+        )
 
     catalog_info.pop("epoch", None)
     catalog_info = catalog_info | args.extra_property_dict()


### PR DESCRIPTION
See https://github.com/astronomy-commons/hats-import/issues/434

Existing margins may have missed many points when generated. Don't allow blind conversion from hipscat -> hats.