### PR TITLE
RA, DEC must be double-precision, not single, for radec2pix

### DIFF
--- a/src/hats_import/margin_cache/margin_cache_map_reduce.py
+++ b/src/hats_import/margin_cache/margin_cache_map_reduce.py
@@ -45,8 +45,8 @@ def map_pixel_shards(
 
         margin_pixel_list = hp.radec2pix(
             margin_order,
-            data[ra_column].values,
-            data[dec_column].values,
+            data[ra_column].values.astype("d"),
+            data[dec_column].values.astype("d"),
         )
         margin_pixel_filter = pd.DataFrame(
             {"margin_pixel": margin_pixel_list, "filter_value": np.arange(0, len(margin_pixel_list))}


### PR DESCRIPTION
## Change Description

Ensure that RA and DEC are double-precision before calling `radec2pix`.  When they are single-precision, that function fails with a `TypeError`.

Closes #458 . Verified during #460 .

<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
- [X] My PR includes a link to the issue that I am addressing

## Code Quality
- [X] I have read the [Contribution Guide](https://hats-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [ ] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### Bug Fix Checklist
- [ ] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

