### PR TITLE
Use a naive sparse histogram.

### DIFF
--- a/src/hats_import/catalog/map_reduce.py
+++ b/src/hats_import/catalog/map_reduce.py
@@ -123,10 +123,7 @@ def map_to_pixels(
         ):
             mapped_pixel, count_at_pixel = np.unique(mapped_pixels, return_counts=True)
 
-            partial = SparseHistogram.make_from_counts(
-                mapped_pixel, count_at_pixel, healpix_order=highest_order
-            )
-            histo.add(partial)
+            histo.add(SparseHistogram(mapped_pixel, count_at_pixel, highest_order))
 
         histo.to_sparse().to_file(
             ResumePlan.partial_histogram_file(tmp_path=resume_path, mapping_key=mapping_key)

--- a/src/hats_import/catalog/map_reduce.py
+++ b/src/hats_import/catalog/map_reduce.py
@@ -10,7 +10,7 @@ import pyarrow.parquet as pq
 from hats import pixel_math
 from hats.io import file_io, paths
 from hats.pixel_math.healpix_pixel import HealpixPixel
-from hats.pixel_math.sparse_histogram import SparseHistogram
+from hats.pixel_math.sparse_histogram import HistogramAggregator, SparseHistogram
 from hats.pixel_math.spatial_index import SPATIAL_INDEX_COLUMN, spatial_index_to_healpix
 from upath import UPath
 
@@ -105,7 +105,7 @@ def map_to_pixels(
         FileNotFoundError: if the file does not exist, or is a directory
     """
     try:
-        histo = SparseHistogram.make_empty(highest_order)
+        histo = HistogramAggregator(highest_order)
 
         if use_healpix_29:
             read_columns = [SPATIAL_INDEX_COLUMN]
@@ -128,7 +128,9 @@ def map_to_pixels(
             )
             histo.add(partial)
 
-        histo.to_file(ResumePlan.partial_histogram_file(tmp_path=resume_path, mapping_key=mapping_key))
+        histo.to_sparse().to_file(
+            ResumePlan.partial_histogram_file(tmp_path=resume_path, mapping_key=mapping_key)
+        )
     except Exception as exception:  # pylint: disable=broad-exception-caught
         print_task_failure(f"Failed MAPPING stage with file {input_file}", exception)
         raise exception

--- a/tests/hats_import/catalog/test_resume_plan.py
+++ b/tests/hats_import/catalog/test_resume_plan.py
@@ -79,7 +79,7 @@ def test_read_write_histogram(tmp_path):
     remaining_keys = plan.get_remaining_map_keys()
     assert remaining_keys == [("map_0", "foo1")]
 
-    histogram = SparseHistogram.make_from_counts([11], [131], 0)
+    histogram = SparseHistogram([11], [131], 0)
     histogram.to_file(ResumePlan.partial_histogram_file(tmp_path=tmp_path, mapping_key="map_0"))
 
     remaining_keys = plan.get_remaining_map_keys()
@@ -118,7 +118,7 @@ def test_some_map_task_failures(tmp_path, dask_client):
     with pytest.raises(RuntimeError, match="map stages"):
         plan.wait_for_mapping(futures)
 
-    histogram = SparseHistogram.make_from_counts([11], [131], 0)
+    histogram = SparseHistogram([11], [131], 0)
     histogram.to_file(ResumePlan.partial_histogram_file(tmp_path=tmp_path, mapping_key="map_0"))
 
     ## Method succeeds, *and* partial histogram is present.

--- a/tests/hats_import/catalog/test_run_import.py
+++ b/tests/hats_import/catalog/test_run_import.py
@@ -47,8 +47,8 @@ def test_resume_dask_runner(
     ## Now set up our resume files to match previous work.
     resume_tmp = tmp_path / "tmp" / "resume_catalog"
     ResumePlan(tmp_path=resume_tmp, progress_bar=False)
-    histogram = SparseHistogram.make_from_counts([11], [131], 0)
-    empty = SparseHistogram.make_empty(0)
+    histogram = SparseHistogram([11], [131], 0)
+    empty = SparseHistogram([], [], 0)
     for file_index in range(0, 5):
         ResumePlan.touch_key_done_file(resume_tmp, ResumePlan.SPLITTING_STAGE, f"split_{file_index}")
         histogram_file = ResumePlan.partial_histogram_file(
@@ -139,7 +139,7 @@ def test_resume_dask_runner_diff_pixel_order(
     ## Now set up our resume files to match previous work.
     resume_tmp = tmp_path / "tmp" / "resume_catalog"
     ResumePlan(tmp_path=resume_tmp, progress_bar=False)
-    SparseHistogram.make_from_counts([11], [131], 0).to_dense_file(resume_tmp / "mapping_histogram.npz")
+    SparseHistogram([11], [131], 0).to_dense_file(resume_tmp / "mapping_histogram.npz")
     for file_index in range(0, 5):
         ResumePlan.touch_key_done_file(resume_tmp, ResumePlan.SPLITTING_STAGE, f"split_{file_index}")
 
@@ -203,8 +203,8 @@ def test_resume_dask_runner_histograms_diff_size(
     ResumePlan(tmp_path=resume_tmp, progress_bar=False)
 
     # We'll create mock partial histograms of size 0 and 2
-    histogram = SparseHistogram.make_empty(0)
-    wrong_histogram = SparseHistogram.make_empty(2)
+    histogram = SparseHistogram([], [], 0)
+    wrong_histogram = SparseHistogram([], [], 2)
 
     for file_index in range(0, 5):
         ResumePlan.touch_key_done_file(resume_tmp, ResumePlan.SPLITTING_STAGE, f"split_{file_index}")


### PR DESCRIPTION
We really just need the non-zero indexes and non-zero values, and the complexity of the general scipy sparse array is adding a lot of compute overhead, primarily in the catalog import "Binning" stage.

https://github.com/astronomy-commons/hats/pull/446