### PR TITLE
Avoid overwriting valid catalogs.

### DIFF
--- a/src/hats_import/catalog/run_import.py
+++ b/src/hats_import/catalog/run_import.py
@@ -5,8 +5,8 @@ The actual logic of the map reduce is in the `map_reduce.py` file.
 """
 
 import os
-from pathlib import Path
 import pickle
+from pathlib import Path
 
 import hats.io.file_io as io
 from hats.catalog import PartitionInfo

--- a/src/hats_import/catalog/run_import.py
+++ b/src/hats_import/catalog/run_import.py
@@ -19,17 +19,26 @@ from hats_import.catalog.arguments import ImportArguments
 from hats_import.catalog.resume_plan import ResumePlan
 
 
-def run(args, client):
-    """Run catalog creation pipeline."""
+def _validate_arguments(args):
+    """
+    Verify that the args for run are valid: they exist, are of the appropriate type,
+    and do not specify an output which is a valid catalog.
+
+    Raises ValueError if they are invalid.
+    """
     if not args:
         raise ValueError("args is required and should be type ImportArguments")
     if not isinstance(args, ImportArguments):
         raise ValueError("args must be type ImportArguments")
 
-    # Verify that the planned output path is not occupied by a valid catalog
     potential_path = Path(args.output_path) / args.output_artifact_name
     if is_valid_catalog(potential_path):
         raise ValueError(f"Output path {potential_path} already contains a valid catalog")
+
+
+def run(args, client):
+    """Run catalog creation pipeline."""
+    _validate_arguments(args)
 
     resume_plan = ResumePlan(import_args=args)
 

--- a/src/hats_import/catalog/run_import.py
+++ b/src/hats_import/catalog/run_import.py
@@ -1,16 +1,18 @@
 """Import a set of non-hats files using dask for parallelization
 
-Methods in this file set up a dask pipeline using futures. 
+Methods in this file set up a dask pipeline using futures.
 The actual logic of the map reduce is in the `map_reduce.py` file.
 """
 
 import os
+from pathlib import Path
 import pickle
 
 import hats.io.file_io as io
 from hats.catalog import PartitionInfo
 from hats.io import paths
 from hats.io.parquet_metadata import write_parquet_metadata
+from hats.io.validation import is_valid_catalog
 
 import hats_import.catalog.map_reduce as mr
 from hats_import.catalog.arguments import ImportArguments
@@ -23,6 +25,11 @@ def run(args, client):
         raise ValueError("args is required and should be type ImportArguments")
     if not isinstance(args, ImportArguments):
         raise ValueError("args must be type ImportArguments")
+
+    # Verify that the planned output path is not occupied by a valid catalog
+    potential_path = Path(args.output_path) / args.output_artifact_name
+    if is_valid_catalog(potential_path):
+        raise ValueError(f"Output path {potential_path} already contains a valid catalog")
 
     resume_plan = ResumePlan(import_args=args)
 

--- a/src/hats_import/margin_cache/margin_cache.py
+++ b/src/hats_import/margin_cache/margin_cache.py
@@ -1,8 +1,10 @@
+from pathlib import Path
 from hats.catalog import PartitionInfo
 from hats.io import file_io, parquet_metadata, paths
 
 import hats_import.margin_cache.margin_cache_map_reduce as mcmr
 from hats_import.margin_cache.margin_cache_resume_plan import MarginCachePlan
+from hats.io.validation import is_valid_catalog
 
 # pylint: disable=too-many-locals,too-many-arguments
 
@@ -15,6 +17,11 @@ def generate_margin_cache(args, client):
         args (MarginCacheArguments): A valid `MarginCacheArguments` object.
         client (dask.distributed.Client): A dask distributed client object.
     """
+    potential_path = Path(args.output_path) / args.output_artifact_name
+    # Verify that the planned output path is not occupied by a valid catalog
+    if is_valid_catalog(potential_path):
+        raise ValueError(f"Output path {potential_path} already contains a valid catalog")
+
     resume_plan = MarginCachePlan(args)
     original_catalog_metadata = paths.get_common_metadata_pointer(args.input_catalog_path)
 

--- a/src/hats_import/margin_cache/margin_cache.py
+++ b/src/hats_import/margin_cache/margin_cache.py
@@ -1,10 +1,11 @@
 from pathlib import Path
+
 from hats.catalog import PartitionInfo
 from hats.io import file_io, parquet_metadata, paths
+from hats.io.validation import is_valid_catalog
 
 import hats_import.margin_cache.margin_cache_map_reduce as mcmr
 from hats_import.margin_cache.margin_cache_resume_plan import MarginCachePlan
-from hats.io.validation import is_valid_catalog
 
 # pylint: disable=too-many-locals,too-many-arguments
 

--- a/tests/hats_import/catalog/test_run_import.py
+++ b/tests/hats_import/catalog/test_run_import.py
@@ -13,11 +13,10 @@ from hats import read_hats
 from hats.pixel_math.sparse_histogram import SparseHistogram
 
 import hats_import.catalog.run_import as runner
+import hats_import.margin_cache.margin_cache as margin_runner
 from hats_import.catalog.arguments import ImportArguments
 from hats_import.catalog.file_readers import CsvReader
 from hats_import.catalog.resume_plan import ResumePlan
-
-import hats_import.margin_cache.margin_cache as margin_runner
 from hats_import.margin_cache.margin_cache_arguments import MarginCacheArguments
 
 


### PR DESCRIPTION
Strong refusal without options, since it's easier and safer to move the catalog out of the way.

## Change Description

Before beginning a catalog import or generating a margin cache, check whether the output artifact already contains a valid catalog, and if so, stop by raising a `ValueError`.

Closes #459 .

- [X] My PR includes a link to the issue that I am addressing

## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->



## Code Quality
- [X] I have read the [Contribution Guide](https://hats-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation

### Bug Fix Checklist

Tested this end-to-end on epyc, and verified it, and added unit tests to verify argument validation.

- [x] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
