### PR TITLE
Pass additional kwargs through import

### DIFF
--- a/src/hats_import/catalog/arguments.py
+++ b/src/hats_import/catalog/arguments.py
@@ -130,14 +130,13 @@ class ImportArguments(RuntimeArguments):
         # Basic checks complete - make more checks and create directories where necessary
         self.input_paths = find_input_paths(self.input_path, "**/*.*", self.input_file_list)
 
-        if self.write_table_kwargs:
-            # If user has provided some args, let's make sure they're good.
-            if "compression" in self.write_table_kwargs:
-                compression_type = self.write_table_kwargs["compression"]
-                ## TODO!
-                print(compression_type)
-        else:
-            self.write_table_kwargs = {"compression": "ZSTD", "compression_level": 15}
+        if self.write_table_kwargs is None:
+            self.write_table_kwargs = {}
+        if "compression" not in self.write_table_kwargs:
+            self.write_table_kwargs = self.write_table_kwargs | {
+                "compression": "ZSTD",
+                "compression_level": 15,
+            }
 
     def to_table_properties(
         self, total_rows: int, highest_order: int, moc_sky_fraction: float

--- a/src/hats_import/catalog/arguments.py
+++ b/src/hats_import/catalog/arguments.py
@@ -46,7 +46,7 @@ class ImportArguments(RuntimeArguments):
     add_healpix_29: bool = True
     """add the healpix-based hats spatial index field alongside the data"""
     write_table_kwargs: dict | None = None
-    """additional keyword arguments to use when writing files to parquet (e.g. compression schemes)"""
+    """additional keyword arguments to use when writing files to parquet (e.g. compression schemes)."""
     row_group_kwargs: dict | None = None
     """additional keyword arguments to use in creation of rowgroups when writing files to parquet."""
 

--- a/src/hats_import/catalog/arguments.py
+++ b/src/hats_import/catalog/arguments.py
@@ -43,6 +43,11 @@ class ImportArguments(RuntimeArguments):
     but the provided sorting will be used for any rows within the same higher-order pixel space."""
     add_healpix_29: bool = True
     """add the healpix-based hats spatial index field alongside the data"""
+    write_table_kwargs: dict | None = None
+    """additional keyword arguments to use when writing files to parquet (e.g. compression schemes)"""
+    row_group_kwargs: dict | None = None
+    """additional keyword arguments to use in creation of rowgroups when writing files to parquet."""
+
     use_schema_file: str | Path | UPath | None = None
     """path to a parquet file with schema metadata. this will be used for column
     metadata when writing the files, if specified"""
@@ -122,6 +127,15 @@ class ImportArguments(RuntimeArguments):
 
         # Basic checks complete - make more checks and create directories where necessary
         self.input_paths = find_input_paths(self.input_path, "**/*.*", self.input_file_list)
+
+        if self.write_table_kwargs:
+            # If user has provided some args, let's make sure they're good.
+            if "compression" in self.write_table_kwargs:
+                compression_type = self.write_table_kwargs["compression"]
+                ## TODO!
+                print(compression_type)
+        else:
+            self.write_table_kwargs = {"compression": "ZSTD", "compression_level": 15}
 
     def to_table_properties(
         self, total_rows: int, highest_order: int, moc_sky_fraction: float

--- a/src/hats_import/catalog/map_reduce.py
+++ b/src/hats_import/catalog/map_reduce.py
@@ -197,6 +197,7 @@ def split_pixels(
         raise exception
 
 
+# pylint: disable=too-many-positional-arguments
 def reduce_pixel_shards(
     cache_shard_path,
     resume_path,
@@ -218,40 +219,33 @@ def reduce_pixel_shards(
     """Reduce sharded source pixels into destination pixels.
 
     In addition to combining multiple shards of data into a single
-    parquet file, this method will add a few new columns:
-
-        - ``Norder`` - the healpix order for the pixel
-        - ``Dir`` - the directory part, corresponding to the pixel
-        - ``Npix`` - the healpix pixel
-        - ``_healpix_29`` - optional - a spatially-correlated
-          64-bit index field.
-
-    Notes on ``_healpix_29``:
-
-        - if we generate the field, we will promote any previous
-          *named* pandas index field(s) to a column with
-          that name.
-        - see ``hats.pixel_math.spatial_index``
-          for more in-depth discussion of this field.
+    parquet file, this method will (optionally) add the ``_healpix_29`` column.
+    See ``hats.pixel_math.spatial_index`` for more in-depth discussion of this field.
 
     Args:
         cache_shard_path (UPath): where to read intermediate parquet files.
         resume_path (UPath): where to write resume files.
         reducing_key (str): unique string for this task, used for resume files.
-        origin_pixel_numbers (list[int]): high order pixels, with object
-            data written to intermediate directories.
         destination_pixel_order (int): order of the final catalog pixel
         destination_pixel_number (int): pixel number at the above order
         destination_pixel_size (int): expected number of rows to write
             for the catalog's final pixel
         output_path (UPath): where to write the final catalog pixel data
+        ra_column (str): where to find right ascension data in the dataframe
+        dec_column (str): where to find declation in the dataframe
         sort_columns (str): column for survey identifier, or other sortable column
+        use_healpix_29 (bool): should we use a pre-existing _healpix_29 column
+            for position information.
         add_healpix_29 (bool): should we add a _healpix_29 column to
             the resulting parquet file?
         delete_input_files (bool): should we delete the intermediate files
             used as input for this method.
         use_schema_file (str): use the parquet schema from the indicated
             parquet file.
+        write_table_kwargs (dict): additional keyword arguments to use when 
+            writing files to parquet (e.g. compression schemes)
+        row_group_kwargs (dict): additional keyword arguments to use in 
+            creation of rowgroups when writing files to parquet.
 
     Raises:
         ValueError: if the number of rows written doesn't equal provided

--- a/src/hats_import/catalog/map_reduce.py
+++ b/src/hats_import/catalog/map_reduce.py
@@ -242,9 +242,9 @@ def reduce_pixel_shards(
             used as input for this method.
         use_schema_file (str): use the parquet schema from the indicated
             parquet file.
-        write_table_kwargs (dict): additional keyword arguments to use when 
+        write_table_kwargs (dict): additional keyword arguments to use when
             writing files to parquet (e.g. compression schemes)
-        row_group_kwargs (dict): additional keyword arguments to use in 
+        row_group_kwargs (dict): additional keyword arguments to use in
             creation of rowgroups when writing files to parquet.
 
     Raises:

--- a/src/hats_import/catalog/map_reduce.py
+++ b/src/hats_import/catalog/map_reduce.py
@@ -232,7 +232,7 @@ def reduce_pixel_shards(
             for the catalog's final pixel
         output_path (UPath): where to write the final catalog pixel data
         ra_column (str): where to find right ascension data in the dataframe
-        dec_column (str): where to find declation in the dataframe
+        dec_column (str): where to find declination in the dataframe
         sort_columns (str): column for survey identifier, or other sortable column
         use_healpix_29 (bool): should we use a pre-existing _healpix_29 column
             for position information.

--- a/src/hats_import/catalog/run_import.py
+++ b/src/hats_import/catalog/run_import.py
@@ -115,6 +115,8 @@ def run(args, client):
                     use_schema_file=args.use_schema_file,
                     use_healpix_29=args.use_healpix_29,
                     delete_input_files=args.delete_intermediate_parquet_files,
+                    write_table_kwargs=args.write_table_kwargs,
+                    row_group_kwargs=args.row_group_kwargs,
                 )
             )
 

--- a/tests/hats_import/catalog/test_run_import.py
+++ b/tests/hats_import/catalog/test_run_import.py
@@ -286,7 +286,11 @@ def test_dask_runner(
             pa.field("dec_error", pa.float32()),
         ]
     )
-    schema = pq.read_metadata(output_file).schema.to_arrow_schema()
+    metadata = pq.read_metadata(output_file)
+    assert metadata.num_row_groups == 1
+    assert metadata.row_group(0).column(0).compression == "ZSTD"
+
+    schema = metadata.schema.to_arrow_schema()
     assert schema.equals(expected_parquet_schema)
     schema = pq.read_metadata(args.catalog_path / "dataset" / "_metadata").schema.to_arrow_schema()
     assert schema.equals(expected_parquet_schema)


### PR DESCRIPTION
Closes #516, #517.
Related to #513.

Passes additional kwarg dictionaries through the import pipeline to use when writing the final parquet tables. 
- `write_table_kwargs` set is passed directly to the `write_table` call, and can specify values for compression
- `row_group_kwargs` defines the row group splitting strategy to use for the parquet files. currently the only strategy supported is the current sort column.