### PR TITLE
Configure row group splitting strategies

### DIFF
--- a/src/hats_import/catalog/map_reduce.py
+++ b/src/hats_import/catalog/map_reduce.py
@@ -288,17 +288,31 @@ def reduce_pixel_shards(
                         merged_table[dec_column].to_numpy().astype(np.float64),
                     )
                 ],
-            ).sort_by(SPATIAL_INDEX_COLUMN)
-
-        merged_table = _split_to_row_groups(
-            merged_table, sort_columns, add_healpix_29 or use_healpix_29, row_group_kwargs
-        )
+            )
 
         if not write_table_kwargs:
             write_table_kwargs = {}
+        if not row_group_kwargs:
+            row_group_kwargs = {}
+
+        sorting_columns = sort_columns.split(",") if sort_columns is not None else []
+        if add_healpix_29 or use_healpix_29:
+            # Sort by healpix_29 first and then by the other sorting columns to resolve unambiguity
+            sorting_columns.insert(0, SPATIAL_INDEX_COLUMN)
+        if sorting_columns:
+            ordering = [(col_name, "ascending") for col_name in sorting_columns]
+            merged_table = merged_table.sort_by(ordering)
+            # For metadata purposes this needs to be of type pq.SortingColumn
+            row_group_kwargs["sorting_columns"] = pq.SortingColumn.from_ordering(
+                merged_table.schema, ordering
+            )
 
         pq.write_table(
-            merged_table, destination_file.path, filesystem=destination_file.fs, **write_table_kwargs
+            merged_table,
+            destination_file.path,
+            filesystem=destination_file.fs,
+            **write_table_kwargs,
+            **row_group_kwargs,
         )
         del merged_table
 
@@ -314,24 +328,3 @@ def reduce_pixel_shards(
             exception,
         )
         raise exception
-
-
-def _split_to_row_groups(table, sort_columns, has_healpix_29, row_group_kwargs):
-    if not row_group_kwargs:
-        row_group_kwargs = {"sort_column": sort_columns}
-
-    if "sort_column" in row_group_kwargs:
-        if sort_columns:
-            split_columns = sort_columns.split(",")
-            if len(split_columns) > 1:
-                table = table.sort_by([(col_name, "ascending") for col_name in split_columns])
-            else:
-                table = table.sort_by(sort_columns)
-        ## this is not ideal, but preserves current behavior.
-        if has_healpix_29:
-            table = table.sort_by(SPATIAL_INDEX_COLUMN)
-        return table
-    if "subtile_order_delta" in row_group_kwargs:
-        ## do it the other way
-        return table
-    return table

--- a/src/hats_import/catalog/map_reduce.py
+++ b/src/hats_import/catalog/map_reduce.py
@@ -303,22 +303,25 @@ def reduce_pixel_shards(
             ordering = [(col_name, "ascending") for col_name in sorting_columns]
             merged_table = merged_table.sort_by(ordering)
             # For metadata purposes this needs to be of type pq.SortingColumn
-            row_group_kwargs["sorting_columns"] = pq.SortingColumn.from_ordering(
+            write_table_kwargs["sorting_columns"] = pq.SortingColumn.from_ordering(
                 merged_table.schema, ordering
             )
 
-        pq.write_table(
-            merged_table,
+        # Obtain the row groups for the target file
+        rowgroup_tables = _split_to_row_groups(merged_table, row_group_kwargs, destination_pixel_order)
+
+        with pq.ParquetWriter(
             destination_file.path,
+            merged_table.schema,
             filesystem=destination_file.fs,
             **write_table_kwargs,
-            **row_group_kwargs,
-        )
-        del merged_table
+        ) as writer:
+            for table in rowgroup_tables:
+                writer.write_table(table)
+        del merged_table, rowgroup_tables
 
         if delete_input_files:
             pixel_dir = get_pixel_cache_directory(cache_shard_path, healpix_pixel)
-
             file_io.remove_directory(pixel_dir, ignore_errors=True)
 
         ResumePlan.reducing_key_done(tmp_path=resume_path, reducing_key=reducing_key)
@@ -328,3 +331,21 @@ def reduce_pixel_shards(
             exception,
         )
         raise exception
+
+
+def _split_to_row_groups(table, row_group_kwargs, pixel_order):
+    """Split the pixel table into its row group chunks according to the specified splitting strategy."""
+    if "num_rows" in row_group_kwargs:
+        chunk_size = row_group_kwargs["num_rows"]
+        return [table.slice(i, chunk_size) for i in range(0, len(table), chunk_size)]
+    if "subtile_order_delta" in row_group_kwargs:
+        split_tables = []
+        parent_pixels = table[SPATIAL_INDEX_COLUMN].to_numpy()
+        target_order = row_group_kwargs["subtile_order_delta"] + pixel_order
+        child_pixs = spatial_index_to_healpix(parent_pixels, target_order=target_order)
+        for child_pix in np.unique(child_pixs):
+            indices = np.where(child_pixs == child_pix)[0]
+            row_group = table.take(pa.array(indices))
+            split_tables.append(row_group)
+        return split_tables
+    return [table]

--- a/tests/hats_import/catalog/test_run_round_trip.py
+++ b/tests/hats_import/catalog/test_run_round_trip.py
@@ -5,7 +5,6 @@ regression the test case is exercising.
 """
 # pylint: disable=too-many-lines
 import glob
-import math
 import os
 from pathlib import Path
 

--- a/tests/hats_import/catalog/test_run_round_trip.py
+++ b/tests/hats_import/catalog/test_run_round_trip.py
@@ -82,9 +82,9 @@ def test_import_with_num_row_groups(
     small_sky_source_dir,
     tmp_path,
 ):
-    """The row group size will be specified using `row_group_kwargs`"""
+    """The row group size will be specified in `row_group_kwargs`"""
     args = ImportArguments(
-        output_artifact_name="small_sky_source_catalog.parquet",
+        output_artifact_name="small_sky_source_catalog",
         input_path=small_sky_source_dir,
         file_reader="csv",
         catalog_type="source",
@@ -140,9 +140,9 @@ def test_import_with_subtile_row_groups(
     small_sky_source_dir,
     tmp_path,
 ):
-    """The row group size will be specified using `row_group_kwargs`"""
+    """The row group subtile splitting will be specified in `row_group_kwargs`"""
     args = ImportArguments(
-        output_artifact_name="small_sky_source_catalog.parquet",
+        output_artifact_name="small_sky_source_catalog",
         input_path=small_sky_source_dir,
         file_reader="csv",
         catalog_type="source",
@@ -154,7 +154,7 @@ def test_import_with_subtile_row_groups(
         highest_healpix_order=2,
         pixel_threshold=3_000,
         progress_bar=False,
-        # Sneak in a test of custom row group size
+        # Sneak in a test of custom subtile splitting
         row_group_kwargs={"subtile_order_delta": 2},
     )
 

--- a/tests/hats_import/catalog/test_run_round_trip.py
+++ b/tests/hats_import/catalog/test_run_round_trip.py
@@ -118,7 +118,8 @@ def test_import_with_num_row_groups(
     # Check that the number of row groups is the one expected
     metadata = pixel.metadata
     assert metadata.num_rows == 2395
-    assert metadata.num_row_groups == math.ceil(metadata.num_rows / 100)
+    # 24 = math.ceil(metadata.num_rows / 100)
+    assert metadata.num_row_groups == 24
     # The last row group has fewer number of rows, which is fine
     assert all(metadata.row_group(i).num_rows == 100 for i in range(metadata.num_row_groups - 1))
 


### PR DESCRIPTION
Add two row group splitting strategies, `num_rows` and `subtile_order_delta`. 

The first one allows to specify a number of rows per row group (e.g. `row_group_kwargs={"num_rows": 100}`). The second allows to specify how many times we should split a destination pixel, each HEALPix split results in a row group at a higher order (e.g. `row_group_kwargs={"subtile_order_delta": 2}`). 

I am also passing the `sort_columns` to the parquet metadata, which is useful for parquet readers.

- [X] My PR includes a link to the issue that I am addressing

## Code Quality
- [X] I have read the [Contribution Guide](https://hats-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation