### PR TITLE
Support nested pandas I/O in latest hats

### DIFF
--- a/src/hats_import/index/map_reduce.py
+++ b/src/hats_import/index/map_reduce.py
@@ -44,7 +44,7 @@ def create_index(args, client):
 
     index_dir = file_io.get_upath(args.catalog_path / "dataset" / "index")
 
-    data = dd.from_map(
+    data = dd.DataFrame(dd.from_map(
         read_leaf_file,
         [
             (
@@ -58,7 +58,7 @@ def create_index(args, client):
         drop_duplicates=args.drop_duplicates,
         schema=args.input_catalog.schema,
         include_order_pixel=args.include_order_pixel,
-    )
+    ))
 
     if args.division_hints is not None and len(args.division_hints) > 2:
         data = data.set_index(args.indexing_column, divisions=args.division_hints)

--- a/src/hats_import/index/map_reduce.py
+++ b/src/hats_import/index/map_reduce.py
@@ -16,7 +16,6 @@ def read_leaf_file(
     data = file_io.read_parquet_file_to_pandas(
         input_file,
         columns=include_columns,
-        engine="pyarrow",
         schema=schema,
     )
 

--- a/src/hats_import/index/map_reduce.py
+++ b/src/hats_import/index/map_reduce.py
@@ -44,7 +44,7 @@ def create_index(args, client):
 
     index_dir = file_io.get_upath(args.catalog_path / "dataset" / "index")
 
-    data = dd.DataFrame(dd.from_map(
+    data = dd.from_map(
         read_leaf_file,
         [
             (
@@ -58,7 +58,7 @@ def create_index(args, client):
         drop_duplicates=args.drop_duplicates,
         schema=args.input_catalog.schema,
         include_order_pixel=args.include_order_pixel,
-    ))
+    )
 
     if args.division_hints is not None and len(args.division_hints) > 2:
         data = data.set_index(args.indexing_column, divisions=args.division_hints)
@@ -70,7 +70,7 @@ def create_index(args, client):
     data = data.repartition(partition_size=args.compute_partition_size)
 
     # Now just write it out to leaf parquet files!
-    result = data.to_parquet(
+    result = dd.DataFrame(data).to_parquet(
         path=index_dir.path,
         engine="pyarrow",
         compute_kwargs={"partition_size": args.compute_partition_size},

--- a/src/hats_import/index/map_reduce.py
+++ b/src/hats_import/index/map_reduce.py
@@ -70,7 +70,7 @@ def create_index(args, client):
     data = data.repartition(partition_size=args.compute_partition_size)
 
     # Now just write it out to leaf parquet files!
-    result = dd.DataFrame(data).to_parquet(
+    result = data.to_parquet(
         path=index_dir.path,
         engine="pyarrow",
         compute_kwargs={"partition_size": args.compute_partition_size},

--- a/tests/hats_import/catalog/test_file_readers.py
+++ b/tests/hats_import/catalog/test_file_readers.py
@@ -118,11 +118,7 @@ def test_csv_reader_parquet_metadata(small_sky_single_file, tmp_path):
         schema_file,
     )
 
-    frame = next(
-        CsvReader(schema_file=schema_file).read(
-            small_sky_single_file
-        )
-    )
+    frame = next(CsvReader(schema_file=schema_file).read(small_sky_single_file))
     assert len(frame) == 131
 
     column_types = frame.dtypes.to_dict()
@@ -211,11 +207,7 @@ def test_csv_reader_pipe_delimited(formats_pipe_csv, tmp_path):
     schema_file = tmp_path / "metadata.parquet"
     pq.write_metadata(parquet_schema_types, schema_file)
 
-    frame = next(
-        CsvReader(
-            schema_file=schema_file, header=None, sep="|"
-        ).read(formats_pipe_csv)
-    )
+    frame = next(CsvReader(schema_file=schema_file, header=None, sep="|").read(formats_pipe_csv))
 
     assert len(frame) == 3
     assert np.all(frame["letters"] == ["AA", "BB", "CC"])

--- a/tests/hats_import/catalog/test_file_readers.py
+++ b/tests/hats_import/catalog/test_file_readers.py
@@ -119,7 +119,7 @@ def test_csv_reader_parquet_metadata(small_sky_single_file, tmp_path):
     )
 
     frame = next(
-        CsvReader(schema_file=schema_file, parquet_kwargs={"dtype_backend": "numpy_nullable"}).read(
+        CsvReader(schema_file=schema_file).read(
             small_sky_single_file
         )
     )
@@ -127,11 +127,11 @@ def test_csv_reader_parquet_metadata(small_sky_single_file, tmp_path):
 
     column_types = frame.dtypes.to_dict()
     expected_column_types = {
-        "id": pd.Int64Dtype(),
-        "ra": pd.Float64Dtype(),
-        "dec": pd.Float64Dtype(),
-        "ra_error": pd.Float64Dtype(),
-        "dec_error": pd.Float64Dtype(),
+        "id": pd.ArrowDtype(pa.int64()),
+        "ra": pd.ArrowDtype(pa.float64()),
+        "dec": pd.ArrowDtype(pa.float64()),
+        "ra_error": pd.ArrowDtype(pa.float64()),
+        "dec_error": pd.ArrowDtype(pa.float64()),
     }
     assert np.all(column_types == expected_column_types)
 
@@ -213,7 +213,7 @@ def test_csv_reader_pipe_delimited(formats_pipe_csv, tmp_path):
 
     frame = next(
         CsvReader(
-            schema_file=schema_file, header=None, sep="|", parquet_kwargs={"dtype_backend": "numpy_nullable"}
+            schema_file=schema_file, header=None, sep="|"
         ).read(formats_pipe_csv)
     )
 
@@ -221,10 +221,10 @@ def test_csv_reader_pipe_delimited(formats_pipe_csv, tmp_path):
     assert np.all(frame["letters"] == ["AA", "BB", "CC"])
     column_types = frame.dtypes.to_dict()
     expected_column_types = {
-        "letters": pd.StringDtype(),
-        "ints": pd.Int64Dtype(),
-        "empty": pd.Int64Dtype(),
-        "numeric": pd.Int64Dtype(),
+        "letters": pd.ArrowDtype(pa.string()),
+        "ints": pd.ArrowDtype(pa.int64()),
+        "empty": pd.ArrowDtype(pa.int64()),
+        "numeric": pd.ArrowDtype(pa.int64()),
     }
     assert np.all(column_types == expected_column_types)
 

--- a/tests/hats_import/catalog/test_run_round_trip.py
+++ b/tests/hats_import/catalog/test_run_round_trip.py
@@ -95,7 +95,6 @@ def test_import_mixed_schema_csv(
             "csv",
             chunksize=1,
             schema_file=Path(mixed_schema_csv_parquet),
-            parquet_kwargs={"dtype_backend": "numpy_nullable"},
         ),
         progress_bar=False,
     )

--- a/tests/hats_import/hipscat_conversion/test_run_conversion.py
+++ b/tests/hats_import/hipscat_conversion/test_run_conversion.py
@@ -89,7 +89,6 @@ def test_run_conversion_object(
     data = file_io.read_parquet_file_to_pandas(
         output_file,
         columns=["id", "ra", "dec", "_healpix_29"],
-        engine="pyarrow",
     )
     assert "_healpix_29" in data.columns
     assert data.index.name is None
@@ -132,9 +131,6 @@ def test_run_conversion_source(
         "object_id",
         "object_ra",
         "object_dec",
-        "Norder",
-        "Dir",
-        "Npix",
     ]
     schema = pq.read_metadata(output_file).schema
     npt.assert_array_equal(schema.names, source_columns)

--- a/tests/hats_import/index/test_run_index.py
+++ b/tests/hats_import/index/test_run_index.py
@@ -92,7 +92,7 @@ def test_run_index_on_source(
     basic_index_parquet_schema = pa.schema(
         [
             pa.field("mag", pa.float64()),
-            pa.field("band", pa.large_string()),
+            pa.field("band", pa.string()),
             pa.field("_healpix_29", pa.int64()),
             pa.field("Norder", pa.uint8()),
             pa.field("Npix", pa.uint64()),


### PR DESCRIPTION
New nested pandas I/O doesn't support different pandas dtype backends, so tests are changed to remove the different backend dtypes and always check for arrow types