### PR TITLE
Generate data thumbnail in the import pipelines

### DIFF
--- a/src/hats_import/catalog/run_import.py
+++ b/src/hats_import/catalog/run_import.py
@@ -130,7 +130,9 @@ def run(args, client):
             partition_info_file = paths.get_partition_info_pointer(args.catalog_path)
             partition_info.write_to_file(partition_info_file)
             if not args.debug_stats_only:
-                parquet_rows = write_parquet_metadata(args.catalog_path)
+                parquet_rows = write_parquet_metadata(
+                    args.catalog_path, create_thumbnail=True, thumbnail_threshold=args.pixel_threshold
+                )
                 if total_rows > 0 and parquet_rows != total_rows:
                     raise ValueError(
                         f"Number of rows in parquet ({parquet_rows}) "

--- a/src/hats_import/hipscat_conversion/run_conversion.py
+++ b/src/hats_import/hipscat_conversion/run_conversion.py
@@ -87,18 +87,17 @@ def run(args: ConversionArguments, client):
         if future.status == "error":
             raise future.exception()
 
-    thumbnail_kwargs = {
-        "create_thumbnail": catalog_type in (CatalogType.OBJECT, CatalogType.SOURCE),
-        "thumbnail_threshold": int(getattr(properties, "hats_max_rows", 1_000_000)),
-    }
-
     with print_progress(
         total=4,
         stage_name="Finishing",
         use_progress_bar=args.progress_bar,
         simple_progress_bar=args.simple_progress_bar,
     ) as step_progress:
-        total_rows = parquet_metadata.write_parquet_metadata(args.catalog_path, **thumbnail_kwargs)
+        total_rows = parquet_metadata.write_parquet_metadata(
+            args.catalog_path,
+            create_thumbnail=(catalog_type in (CatalogType.OBJECT, CatalogType.SOURCE)),
+            thumbnail_threshold=int(getattr(properties, "hats_max_rows", 1_000_000)),
+        )
         if total_rows != properties.total_rows:
             raise ValueError(
                 f"Unexpected number of rows (original: {properties.total_rows}"

--- a/src/hats_import/hipscat_conversion/run_conversion.py
+++ b/src/hats_import/hipscat_conversion/run_conversion.py
@@ -89,7 +89,7 @@ def run(args: ConversionArguments, client):
 
     thumbnail_kwargs = {
         "create_thumbnail": catalog_type in (CatalogType.OBJECT, CatalogType.SOURCE),
-        "thumbnail_threshold": getattr(properties, "hats_max_rows", 1_000_000),
+        "thumbnail_threshold": int(getattr(properties, "hats_max_rows", 1_000_000)),
     }
 
     with print_progress(

--- a/src/hats_import/hipscat_conversion/run_conversion.py
+++ b/src/hats_import/hipscat_conversion/run_conversion.py
@@ -87,13 +87,18 @@ def run(args: ConversionArguments, client):
         if future.status == "error":
             raise future.exception()
 
+    thumbnail_kwargs = {
+        "create_thumbnail": catalog_type in (CatalogType.OBJECT, CatalogType.SOURCE),
+        "thumbnail_threshold": getattr(properties, "hats_max_rows", 1_000_000),
+    }
+
     with print_progress(
         total=4,
         stage_name="Finishing",
         use_progress_bar=args.progress_bar,
         simple_progress_bar=args.simple_progress_bar,
     ) as step_progress:
-        total_rows = parquet_metadata.write_parquet_metadata(args.catalog_path)
+        total_rows = parquet_metadata.write_parquet_metadata(args.catalog_path, **thumbnail_kwargs)
         if total_rows != properties.total_rows:
             raise ValueError(
                 f"Unexpected number of rows (original: {properties.total_rows}"

--- a/tests/hats_import/hipscat_conversion/test_run_conversion.py
+++ b/tests/hats_import/hipscat_conversion/test_run_conversion.py
@@ -93,6 +93,9 @@ def test_run_conversion_object(
     assert "_healpix_29" in data.columns
     assert data.index.name is None
 
+    # Check that the data thumbnail exists
+    assert (args.catalog_path / "dataset" / "data_thumbnail.parquet").exists()
+
 
 @pytest.mark.skipif(not HAVE_HEALPY, reason="healpy is not installed")
 @pytest.mark.dask
@@ -141,3 +144,6 @@ def test_run_conversion_source(
     schema = pq.read_metadata(args.catalog_path / "dataset" / "_common_metadata").schema
     npt.assert_array_equal(schema.names, source_columns)
     assert schema.to_arrow_schema().metadata is None
+
+    # Check that the data thumbnail exists
+    assert (args.catalog_path / "dataset" / "data_thumbnail.parquet").exists()

--- a/tests/hats_import/hipscat_conversion/test_run_conversion.py
+++ b/tests/hats_import/hipscat_conversion/test_run_conversion.py
@@ -6,6 +6,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 from hats.io.file_io import file_io
+from pyarrow.parquet import ParquetFile
 
 import hats_import.hipscat_conversion.run_conversion as runner
 from hats_import.hipscat_conversion.arguments import ConversionArguments
@@ -57,6 +58,7 @@ def test_run_conversion_object(
     catalog = hats.read_hats(args.catalog_path)
     assert catalog.on_disk
     assert catalog.catalog_path == args.catalog_path
+    assert len(catalog.get_healpix_pixels()) == 1
     assert int(catalog.catalog_info.__pydantic_extra__["hats_estsize"]) > 0
 
     # Check that the catalog parquet file exists and contains correct object IDs
@@ -94,7 +96,13 @@ def test_run_conversion_object(
     assert data.index.name is None
 
     # Check that the data thumbnail exists
-    assert (args.catalog_path / "dataset" / "data_thumbnail.parquet").exists()
+    data_thumbnail_pointer = args.catalog_path / "dataset" / "data_thumbnail.parquet"
+    assert data_thumbnail_pointer.exists()
+    thumbnail = ParquetFile(data_thumbnail_pointer)
+    thumbnail_schema = thumbnail.metadata.schema.to_arrow_schema()
+    assert thumbnail_schema.equals(expected_parquet_schema)
+    # The thumbnail has 1 row because the catalog has only 1 pixel
+    assert len(thumbnail.read()) == 1
 
 
 @pytest.mark.skipif(not HAVE_HEALPY, reason="healpy is not installed")
@@ -120,6 +128,7 @@ def test_run_conversion_source(
     catalog = hats.read_hats(args.catalog_path)
     assert catalog.on_disk
     assert catalog.catalog_path == args.catalog_path
+    assert len(catalog.get_healpix_pixels()) == 14
 
     output_file = args.catalog_path / "dataset" / "Norder=2" / "Dir=0" / "Npix=185.parquet"
 
@@ -146,4 +155,10 @@ def test_run_conversion_source(
     assert schema.to_arrow_schema().metadata is None
 
     # Check that the data thumbnail exists
-    assert (args.catalog_path / "dataset" / "data_thumbnail.parquet").exists()
+    data_thumbnail_pointer = args.catalog_path / "dataset" / "data_thumbnail.parquet"
+    assert data_thumbnail_pointer.exists()
+    thumbnail = ParquetFile(data_thumbnail_pointer)
+    thumbnail_schema = thumbnail.metadata.schema.to_arrow_schema()
+    assert thumbnail_schema.equals(schema.to_arrow_schema())
+    # The thumbnail has 14 rows because the catalog has 14 pixels
+    assert len(thumbnail.read()) == 14

--- a/tests/hats_import/margin_cache/test_margin_cache.py
+++ b/tests/hats_import/margin_cache/test_margin_cache.py
@@ -57,6 +57,10 @@ def test_margin_cache_gen(small_sky_source_catalog, tmp_path, dask_client):
     assert catalog.on_disk
     assert catalog.catalog_path == args.catalog_path
 
+    # Check that the data thumbnail does not exist. It should only exist for
+    # main object/source catalogs.
+    assert not (args.catalog_path / "dataset" / "data_thumbnail.parquet").exists()
+
 
 @pytest.mark.dask(timeout=150)
 def test_margin_cache_gen_negative_pixels(small_sky_source_catalog, tmp_path, dask_client):


### PR DESCRIPTION
Create the data thumbnail parquet in the pipeline for main object/source catalogs.

## Code Quality
- [X] I have read the [Contribution Guide](https://hats-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation