### PR TITLE
Remove directory-specific checks.

### DIFF
--- a/src/hats_import/runtime_arguments.py
+++ b/src/hats_import/runtime_arguments.py
@@ -164,9 +164,6 @@ def find_input_paths(input_path="", file_matcher="", input_file_list=None):
     if input_path:
         if input_file_list:
             raise ValueError("exactly one of input_path or input_file_list is required")
-
-        if not file_io.does_file_or_directory_exist(input_path):
-            raise FileNotFoundError("input_path not found on local storage")
         input_paths = file_io.find_files_matching_path(input_path, file_matcher)
     elif input_file_list is not None:
         # It's common for users to accidentally pass in an empty list. Give them a friendly error.

--- a/src/hats_import/verification/arguments.py
+++ b/src/hats_import/verification/arguments.py
@@ -44,12 +44,9 @@ class VerificationArguments:
 
     def __post_init__(self) -> None:
         self.input_catalog_path = file_io.get_upath(self.input_catalog_path)
-        if not self.input_catalog_path.is_dir():
-            raise ValueError("input_catalog_path must be an existing directory")
-
         self.output_path = file_io.get_upath(self.output_path)
 
         if self.truth_schema is not None:
             self.truth_schema = file_io.append_paths_to_pointer(self.truth_schema)
             if not self.truth_schema.exists():
-                raise ValueError("truth_schema must be an existing file or directory")
+                raise FileNotFoundError("truth_schema must be an existing file or directory")

--- a/tests/hats_import/catalog/test_run_round_trip.py
+++ b/tests/hats_import/catalog/test_run_round_trip.py
@@ -3,6 +3,7 @@
 Please add a brief description in the docstring of the features or specific
 regression the test case is exercising.
 """
+
 # pylint: disable=too-many-lines
 import glob
 import os

--- a/tests/hats_import/verification/test_verification_arguments.py
+++ b/tests/hats_import/verification/test_verification_arguments.py
@@ -10,12 +10,8 @@ def test_invalid_paths(tmp_path, small_sky_object_catalog):
     ## Prove that it works with required args
     VerificationArguments(input_catalog_path=small_sky_object_catalog, output_path=tmp_path)
 
-    ## Input path is not an existing directory
-    with pytest.raises(ValueError, match="input_catalog_path must be an existing directory"):
-        VerificationArguments(input_catalog_path="path", output_path=f"{tmp_path}/path")
-
     # Truth schema is not an existing file
-    with pytest.raises(ValueError, match="truth_schema must be an existing file or directory"):
+    with pytest.raises(FileNotFoundError, match="truth_schema must be an existing file or directory"):
         VerificationArguments(
             input_catalog_path=small_sky_object_catalog, output_path=tmp_path, truth_schema="path"
         )


### PR DESCRIPTION
Checks against middle-directories are not useful on Google Cloud Storage file system, as these paths don't really exist. AWS pretends they do, but GCS does not. The checks that are failing aren't particularly useful, and the missing files/directories are caught elsewhere.