### PR TITLE
Re-arrange import documentation.

### DIFF
--- a/docs/catalogs/collections.rst
+++ b/docs/catalogs/collections.rst
@@ -1,0 +1,4 @@
+Catalog Collections
+===============================================================================
+
+TODO - placeholder for discussion of creating a catalog collection in a single pipeline.

--- a/docs/catalogs/file_readers.rst
+++ b/docs/catalogs/file_readers.rst
@@ -1,0 +1,6 @@
+File Readers
+======================================
+
+TODO - placeholder for longer discussion of ``file_readers``.
+
+Issue https://github.com/astronomy-commons/hats-import/issues/527

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -1,0 +1,45 @@
+About
+==========================
+
+HATS and HATS import is an open source project and is free for all to use. It is released under the liberal terms of the 
+`BSD 3-Clause License <https://github.com/astronomy-commons/lsdb/blob/main/LICENSE>`_.
+
+Citation
+--------------------------
+
+If HATS has been significant in your research, and you would like to 
+acknowledge the project in your academic publication, we suggest citing 
+the conference proceedings:
+
+.. code-block:: bash
+
+    @ARTICLE{2025arXiv250102103C,
+        author        = {{Caplar}, Neven and {Beebe}, Wilson and {Branton}, Doug and {Campos}, Sandro and {Connolly}, Andrew and {DeLucchi}, Melissa and {Jones}, Derek and {Juric}, Mario and {Kubica}, Jeremy and {Malanchev}, Konstantin and {Mandelbaum}, Rachel and {McGuire}, Sean},
+        title         = "{Using LSDB to enable large-scale catalog distribution, cross-matching, and analytics}",
+        journal       = {arXiv e-prints},
+        keywords      = {Astrophysics - Instrumentation and Methods for Astrophysics},
+        year          = 2025,
+        month         = jan,
+        eid           = {arXiv:2501.02103},
+        pages         = {arXiv:2501.02103},
+        doi           = {10.48550/arXiv.2501.02103},
+        archivePrefix = {arXiv},
+        eprint        = {2501.02103},
+        primaryClass  = {astro-ph.IM},
+        adsurl        = {https://ui.adsabs.harvard.edu/abs/2025arXiv250102103C},
+        adsnote       = {Provided by the SAO/NASA Astrophysics Data System}
+    }
+
+
+Acknowledgements
+-------------------------------------------------------------------------------
+
+This project is supported by Schmidt Sciences.
+
+This project is based upon work supported by the National Science Foundation
+under Grant No. AST-2003196.
+
+This project acknowledges support from the DIRAC Institute in the Department of 
+Astronomy at the University of Washington. The DIRAC Institute is supported 
+through generous gifts from the Charles and Lisa Simonyi Fund for Arts and 
+Sciences, and the Washington Research Foundation.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,0 +1,77 @@
+
+Getting Started with HATS import
+====================================================
+
+Installation
+-------------------------------------------------------------------------------
+
+We recommend installing in a virtual environment, like venv or conda. You may
+need to install or upgrade versions of dependencies to work with hats-import.
+
+.. code-block:: console
+
+   >> conda create env -n <env_name> python=3.11
+   >> conda activate <env_name>
+
+.. tip::
+    Installing optional dependencies
+
+    There are some extra dependencies that can make running hats-import in a jupyter
+    environment easier, or connecting to a variety of remote file systems.
+
+    These can be installed with the ``full`` extra.
+
+    .. code-block:: console
+
+        >> pip install hats-import[full]
+
+.. tip::
+    Installing on Mac
+
+    ``healpy`` is an optional dependency for hats-import (included in the ``full`` extra)
+    to support converting from older HiPSCat catalogs, but
+    native prebuilt binaries for healpy on Apple Silicon Macs 
+    `do not yet exist <https://healpy.readthedocs.io/en/latest/install.html#binary-installation-with-pip-recommended-for-most-other-python-users>`__, 
+    so it's recommended to install via conda before proceeding to hats-import.
+
+    .. code-block:: console
+
+        >> conda config --append channels conda-forge
+        >> conda install healpy
+
+
+
+Setting up a pipeline
+-------------------------------------------------------------------------------
+
+For each type of dataset the hats-import tool can generate, there is an argument
+container class that you will need to instantiate and populate with relevant arguments.
+
+See dataset-specific notes on arguments:
+
+* :doc:`catalogs/arguments` (most common)
+* :doc:`guide/hipscat_conversion`
+* :doc:`guide/margin_cache`
+* :doc:`guide/index_table`
+* :doc:`guide/reimporting`
+
+Once you have created your arguments object, you pass it into the pipeline control,
+and then wait. Running within a main guard will potentially avoid some python
+threading issues with dask:
+
+.. code-block:: python
+
+    from dask.distributed import Client
+    from hats_import.pipeline import pipeline_with_client
+
+    def main():
+        args = ...
+        with Client(
+            n_workers=10,
+            threads_per_worker=1,
+            ... 
+        ) as client:
+            pipeline_with_client(args, client)
+
+    if __name__ == '__main__':
+        main()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,123 +1,61 @@
 HATS Import
 ========================================================================================
 
-Utility for ingesting large survey data into HATS structure.
+HATS is a directory structure and metadata for spatially arranging large catalog survey data. 
+This was originally motivated by a desire to perform spatial cross-matching between surveys 
+at large scale, but is applicable to a range of spatial analysis and algorithms.
 
-Installation
--------------------------------------------------------------------------------
+.. attention::
 
-We recommend installing in a virtual environment, like venv or conda. You may
-need to install or upgrade versions of dependencies to work with hats-import.
+    If you already have catalog in HATS format
+    and are just looking to ingest it or analyze it, you can look instead to ``LSDB``, 
+    a python tool for scalable analysis of large catalogs (e.g. querying 
+    and crossmatching ~10⁹ sources). It aims to address large-scale data processing 
+    challenges, in particular those brought up by `LSST <https://www.lsst.org/about>`_.
 
-.. code-block:: console
-
-   >> conda create env -n <env_name> python=3.11
-   >> conda activate <env_name>
-
-.. tip::
-    Installing optional dependencies
-
-    There are some extra dependencies that can make running hats-import in a jupyter
-    environment easier, or connecting to a variety of remote file systems.
-
-    These can be installed with the ``full`` extra.
-
-    .. code-block:: console
-
-        >> pip install hats-import[full]
-
-.. tip::
-    Installing on Mac
-
-    ``healpy`` is an optional dependency for hats-import (included in the ``full`` extra)
-    to support converting from older HiPSCat catalogs, but
-    native prebuilt binaries for healpy on Apple Silicon Macs 
-    `do not yet exist <https://healpy.readthedocs.io/en/latest/install.html#binary-installation-with-pip-recommended-for-most-other-python-users>`__, 
-    so it's recommended to install via conda before proceeding to hats-import.
-
-    .. code-block:: console
-
-        >> conda config --append channels conda-forge
-        >> conda install healpy
-
-
-
-Setting up a pipeline
--------------------------------------------------------------------------------
-
-For each type of dataset the hats-import tool can generate, there is an argument
-container class that you will need to instantiate and populate with relevant arguments.
-
-See dataset-specific notes on arguments:
-
-* :doc:`catalogs/arguments` (most common)
-* :doc:`guide/hipscat_conversion`
-* :doc:`guide/margin_cache`
-* :doc:`guide/index_table`
-* :doc:`guide/reimporting`
-
-Once you have created your arguments object, you pass it into the pipeline control,
-and then wait. Running within a main guard will potentially avoid some python
-threading issues with dask:
-
-.. code-block:: python
-
-    from dask.distributed import Client
-    from hats_import.pipeline import pipeline_with_client
-
-    def main():
-        args = ...
-        with Client(
-            n_workers=10,
-            threads_per_worker=1,
-            ... 
-        ) as client:
-            pipeline_with_client(args, client)
-
-    if __name__ == '__main__':
-        main()
+The ``hats-import`` package provides purpose-built map-reduce pipelines for converting
+large or custom catalogs into HATS format. 
 
 .. toctree::
-   :hidden:
-   :maxdepth: 2
-   :caption: Catalogs
+   :maxdepth: 1
+   :caption: Using HATS import
+
+   Home page <self>
+   Getting Started <getting_started>
+   guide/contact
+   About <citation>
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Typical Catalog Creation
 
    catalogs/arguments
-   guide/hipscat_conversion
    catalogs/temp_files
    catalogs/properties
-   guide/verification
-   catalogs/public/index
-   guide/reimporting
+   catalogs/collections
+   catalogs/file_readers
 
 .. toctree::
-   :hidden:
+   :maxdepth: 1
+   :caption: Catalog Customization
+
+   catalogs/public/index
+   guide/verification
+   guide/reimporting
+   guide/hipscat_conversion
+   Notebooks <notebooks>
+   guide/dask_on_ray
+
+.. toctree::
    :maxdepth: 1
    :caption: Other Datasets
 
    guide/margin_cache
    guide/index_table   
-   Notebooks <notebooks>
-   guide/dask_on_ray
 
 .. toctree::
-   :hidden:
    :maxdepth: 1
    :caption: Developers
 
    guide/contributing
    API Reference <autoapi/index>
-   guide/contact
-
-Acknowledgements
--------------------------------------------------------------------------------
-
-This project is supported by Schmidt Sciences.
-
-This project is based upon work supported by the National Science Foundation
-under Grant No. AST-2003196.
-
-This project acknowledges support from the DIRAC Institute in the Department of 
-Astronomy at the University of Washington. The DIRAC Institute is supported 
-through generous gifts from the Charles and Lisa Simonyi Fund for Arts and 
-Sciences, and the Washington Research Foundation.

--- a/docs/pre_executed/backport_collection.ipynb
+++ b/docs/pre_executed/backport_collection.ipynb
@@ -58,7 +58,7 @@
     "catalog_subdir = \"main_catalog\"\n",
     "margin_paths = [\"margin_1deg\", \"margin_20deg\"]\n",
     "default_margin = \"margin_1deg\"\n",
-    "index_paths = {\"id\":\"id_index\"}\n",
+    "index_paths = {\"id\": \"id_index\"}\n",
     "\n",
     "## This is a human-readable name of the collection, often the survey or data release.\n",
     "collection_name = \"survey_drK\""
@@ -170,8 +170,7 @@
    "source": [
     "from hats.catalog.dataset.collection_properties import CollectionProperties\n",
     "\n",
-    "properties = CollectionProperties(obs_collection= collection_name,\n",
-    "                                 hats_primary_table_url = catalog_subdir)\n",
+    "properties = CollectionProperties(obs_collection=collection_name, hats_primary_table_url=catalog_subdir)\n",
     "properties.to_properties_file(collection_path)"
    ]
   },
@@ -206,7 +205,7 @@
    "outputs": [],
    "source": [
     "## if you added any margins, this will be the list of all margins\n",
-    "new_collection.hc_collection.all_margins\n"
+    "new_collection.hc_collection.all_margins"
    ]
   },
   {
@@ -217,7 +216,7 @@
    "outputs": [],
    "source": [
     "## if you added any indexes, this will be the map of field -> index table\n",
-    "new_collection.hc_collection.all_indexes\n"
+    "new_collection.hc_collection.all_indexes"
    ]
   }
  ],


### PR DESCRIPTION
In advance of writing some more documentation pages for HATS-import, I wanted to clean up the home page and navigation.

- Give a warning that folks might want to look at LSDB instead.
- Move acknowledgements into `citation.rst`, and add citation text
- Move up the `Contact` page in the TOC - 
- Move installation and quick start to separate page
- add the TOC to the home page to encourage a particular sequence of reading
- Break out the most typical pages folks will need to create a catalog from the more niche customization
- placeholders for new documentation pages.