### PR TITLE
Run verification through typical `pipeline` construction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "pylint", # Used for static linting of files
     "pytest",
     "pytest-cov",
+    "pytest-mock",
     "pytest-timeout",
 ]
 full = [

--- a/src/hats_import/__init__.py
+++ b/src/hats_import/__init__.py
@@ -1,4 +1,10 @@
 """All modules for hats-import package"""
 
 from ._version import __version__
+from .catalog import ImportArguments
+from .collection import CollectionArguments
+from .index import IndexArguments
+from .margin_cache.margin_cache_arguments import MarginCacheArguments
+from .pipeline import pipeline, pipeline_with_client
 from .runtime_arguments import RuntimeArguments
+from .verification.arguments import VerificationArguments

--- a/src/hats_import/pipeline.py
+++ b/src/hats_import/pipeline.py
@@ -24,6 +24,9 @@ from hats_import.verification.arguments import VerificationArguments
 
 def pipeline(args: RuntimeArguments):
     """Pipeline that creates its own client from the provided runtime arguments"""
+    if isinstance(args, VerificationArguments):
+        verification_runner.run(args)
+        return
     with Client(
         local_directory=args.dask_tmp,
         n_workers=args.dask_n_workers,
@@ -36,8 +39,11 @@ def pipeline_with_client(args: RuntimeArguments, client: Client):
     """Pipeline that is run using an existing client.
 
     This can be useful in tests, or when a dask client requires some more complex
-    configuraion.
+    configuration.
     """
+    if isinstance(args, VerificationArguments):
+        verification_runner.run(args)
+        return
     try:
         if not args:
             raise ValueError("args is required and should be subclass of RuntimeArguments")

--- a/src/hats_import/verification/arguments.py
+++ b/src/hats_import/verification/arguments.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Literal
 
 import hats.io.paths
 from hats.io import file_io
@@ -31,6 +32,13 @@ class VerificationArguments:
     string or path object."""
     verbose: bool = True
     """Should we output progress and results to standard out?"""
+    write_mode: Literal["a", "w", "x"] = "a"
+    """Mode to be used when writing the output file. Options have the typical meanings:
+        - 'w': truncate the file first
+        - 'x': exclusive creation, failing if the file already exists
+        - 'a': append to the end of file if it exists"""
+    check_metadata: bool = False
+    """Whether to check the metadata as well as the schema."""
 
     @property
     def input_dataset_path(self) -> UPath:

--- a/tests/hats_import/catalog/test_reimport_hats.py
+++ b/tests/hats_import/catalog/test_reimport_hats.py
@@ -107,8 +107,7 @@ def test_reimport_arguments_catalog_collection(test_data_dir, small_sky_object_c
     assert args.dec_column == catalog.catalog_info.dec_column
 
 
-@pytest.mark.timeout(10)
-@pytest.mark.dask
+@pytest.mark.dask(timeout=10)
 def test_run_reimport(
     dask_client,
     small_sky_object_catalog,

--- a/tests/hats_import/test_pipeline_run.py
+++ b/tests/hats_import/test_pipeline_run.py
@@ -1,0 +1,59 @@
+import pandas as pd
+import pytest
+
+import hats_import
+from email.message import EmailMessage
+
+
+def test_runner(small_sky_object_catalog, tmp_path):
+    """Runner should execute all tests and write a report to file."""
+    args = hats_import.VerificationArguments(
+        input_catalog_path=small_sky_object_catalog, output_path=tmp_path, verbose=False, write_mode="w"
+    )
+    hats_import.pipeline(args)
+    hats_import.pipeline_with_client(args, None)
+
+
+@pytest.mark.dask(timeout=10)
+def test_reimport_runner(dask_client, small_sky_object_catalog, tmp_path, mocker):
+    mock_smtp = mocker.patch("smtplib.SMTP")
+
+    args = hats_import.ImportArguments.reimport_from_hats(
+        small_sky_object_catalog,
+        tmp_path,
+        output_artifact_name="small_sky_higher_order",
+        highest_healpix_order=1,
+        completion_email_address="nonsense",
+    )
+
+    hats_import.pipeline_with_client(args, dask_client)
+    mock_smtp.assert_called_once_with("localhost")
+    mock_smtp.return_value.__enter__.return_value.send_message.assert_called_once()
+    sent_message = mock_smtp.return_value.__enter__.return_value.send_message.call_args.args[0]
+    assert sent_message["Subject"] == "hats-import success."
+    assert sent_message["To"] == "nonsense"
+    assert sent_message["From"] == "updates@lsdb.io"
+    assert sent_message.get_content().startswith("output_artifact_name: small_sky_higher_order")
+
+
+@pytest.mark.dask(timeout=10)
+def test_email_error(small_sky_object_catalog, tmp_path, mocker):
+    mock_smtp = mocker.patch("smtplib.SMTP")
+
+    args = hats_import.ImportArguments.reimport_from_hats(
+        small_sky_object_catalog,
+        tmp_path,
+        output_artifact_name="small_sky_higher_order",
+        highest_healpix_order=1,
+        completion_email_address="nonsense",
+    )
+    with pytest.raises(AttributeError):
+        hats_import.pipeline_with_client(args, None)
+
+    mock_smtp.assert_called_once_with("localhost")
+    mock_smtp.return_value.__enter__.return_value.send_message.assert_called_once()
+    sent_message = mock_smtp.return_value.__enter__.return_value.send_message.call_args.args[0]
+    assert sent_message["Subject"] == "hats-import failure."
+    assert sent_message["To"] == "nonsense"
+    assert sent_message["From"] == "updates@lsdb.io"
+    assert sent_message.get_content().startswith("output_artifact_name: small_sky_higher_order")

--- a/tests/hats_import/verification/test_run_verification.py
+++ b/tests/hats_import/verification/test_run_verification.py
@@ -20,17 +20,17 @@ def test_runner(small_sky_object_catalog, wrong_files_and_rows_dir, tmp_path):
     result_cols = ["datetime", "passed", "test", "target"]
 
     args = VerificationArguments(
-        input_catalog_path=small_sky_object_catalog, output_path=tmp_path, verbose=False
+        input_catalog_path=small_sky_object_catalog, output_path=tmp_path, verbose=False, write_mode="w"
     )
-    verifier = runner.run(args, write_mode="w")
+    verifier = runner.run(args)
     assert verifier.all_tests_passed, "good catalog failed"
     written_results = pd.read_csv(args.output_path / args.output_filename, comment="#")
     assert written_results[result_cols].equals(verifier.results_df[result_cols]), "report failed"
 
     args = VerificationArguments(
-        input_catalog_path=wrong_files_and_rows_dir, output_path=tmp_path, verbose=False
+        input_catalog_path=wrong_files_and_rows_dir, output_path=tmp_path, verbose=False, write_mode="w"
     )
-    verifier = runner.run(args, write_mode="w")
+    verifier = runner.run(args)
     assert not verifier.all_tests_passed, "bad catalog passed"
     written_results = pd.read_csv(args.output_path / args.output_filename, comment="#")
     assert written_results[result_cols].equals(verifier.results_df[result_cols]), "report failed"
@@ -115,9 +115,10 @@ def test_test_schemas(small_sky_object_catalog, bad_schemas_dir, tmp_path, check
         output_path=tmp_path,
         truth_schema=small_sky_object_catalog / "dataset/_common_metadata",
         verbose=False,
+        check_metadata=check_metadata,
     )
     verifier = runner.Verifier.from_args(args)
-    verifier.test_schemas(check_metadata=check_metadata)
+    verifier.test_schemas()
     assert verifier.all_tests_passed, "good catalog failed"
 
     # Show that bad schemas fail.
@@ -126,9 +127,10 @@ def test_test_schemas(small_sky_object_catalog, bad_schemas_dir, tmp_path, check
         output_path=tmp_path,
         truth_schema=bad_schemas_dir / "dataset/_common_metadata.import_truth",
         verbose=False,
+        check_metadata=check_metadata,
     )
     verifier = runner.Verifier.from_args(args)
-    verifier.test_schemas(check_metadata=check_metadata)
+    verifier.test_schemas()
     results = verifier.results_df
 
     # Expecting _common_metadata and some file footers to always fail


### PR DESCRIPTION
There are a lot of changes in here, that might not seem related, so I'll try to explain:

- adds some more imports in the top-level init. that's really not related, but if I send this Kostya, it will be ok
- don't use a client creation context for verification - there's no dask client needed (and no dask-client-creation arguments)
- don't use the try/except context for verification - there's no completion email address
- move the `write_mode` and `check_metadata` arguments into the `VerificationArguments` object, so there are no additional kwargs to pass to the verifier run method
- add tests to confirm that we send a completion email address.