### PR TITLE
Check for existing supplemental tables in collection import.

### DIFF
--- a/tests/hats_import/collection/test_collection_arguments.py
+++ b/tests/hats_import/collection/test_collection_arguments.py
@@ -255,6 +255,68 @@ def test_collection_properties_supplemental(tmp_path, small_sky_object_catalog):
     assert index_args.output_artifact_name == "small_sky_object_catalog_id"
 
 
+def test_collection_properties_existing_supplemental(tmp_path, small_sky_object_catalog):
+    """If we have already created a catalog or supplemental table in the
+    collection, confirm that the collection properties are written with
+    the union of supplemental tables."""
+    args = (
+        CollectionArguments(
+            output_artifact_name="small_sky_collection",
+            new_catalog_name="small_sky",
+            output_path=tmp_path,
+            progress_bar=False,
+            addl_hats_properties={"obs_regime": "Optical"},
+        ).catalog(
+            catalog_path=small_sky_object_catalog,
+        )
+        # .add_margin(margin_threshold=5.0, is_default=True)
+        # .add_margin(margin_threshold=35.0)
+        # .add_index(indexing_column="id")
+    )
+
+    collection_info = args.to_collection_properties()
+    collection_info.to_properties_file(args.catalog_path)
+
+    args = (
+        CollectionArguments(
+            output_artifact_name="small_sky_collection",
+            new_catalog_name="small_sky",
+            output_path=tmp_path,
+            progress_bar=False,
+        )
+        .catalog(
+            catalog_path=small_sky_object_catalog,
+        )
+        .add_margin(margin_threshold=5.0, is_default=True)
+        # .add_margin(margin_threshold=35.0)
+        .add_index(indexing_column="id")
+    )
+
+    collection_info = args.to_collection_properties()
+    collection_info.to_properties_file(args.catalog_path)
+
+    args = (
+        CollectionArguments(
+            output_artifact_name="small_sky_collection",
+            new_catalog_name="small_sky",
+            output_path=tmp_path,
+            progress_bar=False,
+        ).catalog(
+            catalog_path=small_sky_object_catalog,
+        )
+        # .add_margin(margin_threshold=5.0, is_default=True)
+        .add_margin(margin_threshold=35.0)
+        # .add_index(indexing_column="id")
+    )
+
+    collection_info = args.to_collection_properties()
+    assert collection_info.name == "small_sky_collection"
+    assert len(collection_info.all_margins) == 2
+    assert collection_info.default_margin == "small_sky_object_catalog_5arcs"
+    assert len(collection_info.all_indexes) == 1
+    assert collection_info.__pydantic_extra__["obs_regime"] == "Optical"
+
+
 def test_collection_default_margin(tmp_path, small_sky_object_catalog):
     """Test behavior of the default margin setting."""
     ## Easy case - name derived from primary catalog

--- a/tests/hats_import/collection/test_collection_import.py
+++ b/tests/hats_import/collection/test_collection_import.py
@@ -73,3 +73,100 @@ def test_import_collection(
 
     catalog = read_hats(tmp_path / "small_sky" / "small_sky_source_id")
     assert catalog.catalog_info.total_rows == 17161
+
+    ## Re-running shouldn't create any new tables.
+    args = (
+        CollectionArguments(
+            output_artifact_name="small_sky",
+            output_path=tmp_path,
+            progress_bar=False,
+        )
+        .catalog(
+            input_path=small_sky_source_dir,
+            file_reader="csv",
+            catalog_type="source",
+            ra_column="source_ra",
+            dec_column="source_dec",
+            sort_columns="source_id",
+            highest_healpix_order=2,
+        )
+        .add_margin(margin_threshold=5.0)
+        .add_margin(margin_threshold=50.0)
+        .add_index(indexing_column="object_id", include_healpix_29=False)
+        .add_index(indexing_column="source_id", include_healpix_29=False)
+    )
+    run(args, dask_client)
+
+    collection = read_hats(tmp_path / "small_sky")
+    assert collection.collection_path == args.catalog_path
+
+    ## Don't worry about order for this equality test.
+    assert set(collection.all_margins) == set(["small_sky_50arcs", "small_sky_5arcs"])
+    assert collection.all_indexes == {"object_id": "small_sky_object_id", "source_id": "small_sky_source_id"}
+
+
+@pytest.mark.dask(timeout=150)
+def test_import_collection_resume_supplemental(
+    dask_client,
+    small_sky_source_dir,
+    tmp_path,
+):
+    args = (
+        CollectionArguments(
+            output_artifact_name="small_sky",
+            output_path=tmp_path,
+            progress_bar=False,
+        )
+        .catalog(
+            input_path=small_sky_source_dir,
+            file_reader="csv",
+            catalog_type="source",
+            ra_column="source_ra",
+            dec_column="source_dec",
+            sort_columns="source_id",
+            highest_healpix_order=2,
+        )
+        .add_margin(margin_threshold=5.0)
+        .add_margin(margin_threshold=50.0)
+        .add_index(indexing_column="object_id", include_healpix_29=False)
+        .add_index(indexing_column="not_a_good_column", include_healpix_29=False)
+    )
+    with pytest.raises(match="not_a_good_column"):
+        run(args, dask_client)
+
+    ## Re-running should complete successfully.
+    args = (
+        CollectionArguments(
+            output_artifact_name="small_sky",
+            output_path=tmp_path,
+            progress_bar=False,
+        )
+        .catalog(
+            input_path=small_sky_source_dir,
+            file_reader="csv",
+            catalog_type="source",
+            ra_column="source_ra",
+            dec_column="source_dec",
+            sort_columns="source_id",
+            highest_healpix_order=2,
+        )
+        .add_margin(margin_threshold=5.0)
+        .add_margin(margin_threshold=50.0)
+        .add_index(indexing_column="object_id", include_healpix_29=False)
+        .add_index(indexing_column="source_id", include_healpix_29=False)
+    )
+    ## Margins and one index have already been created successfully,
+    ## and should not be modified by this execution.
+    assert len(args.get_margin_args()) == 0
+    assert len(args.get_index_args()) == 1
+    run(args, dask_client)
+
+    collection = read_hats(tmp_path / "small_sky")
+    assert collection.collection_path == args.catalog_path
+
+    ## Don't worry about order for this equality test.
+    ## What we really are testing here is that the margins are included in the
+    ## Collection properties, even though they were created by a previous (unsuccessful) run
+    ## of the pipeline, and were not included in the properties file at that time.
+    assert set(collection.all_margins) == set(["small_sky_50arcs", "small_sky_5arcs"])
+    assert collection.all_indexes == {"object_id": "small_sky_object_id", "source_id": "small_sky_source_id"}


### PR DESCRIPTION
Closes #565 

Two behaviors should be covered by this PR:

- a previous execution was successful and there is already a collection at the provided path
    - should still create the new supplemental tables
    - existing tables should not spawn sub-pipelines
    - collection properties should be appended, instead of overwritten
- a previous execution was partially successful, and there are supplemental tables present
    - new supplemental tables should be written
    - existing tables should not spawn sub-pipelines
    - a new collection properties should be written, that includes all supplemental tables