### PR TITLE
Make thumbnail generation optional.

### DIFF
--- a/src/hats_import/catalog/arguments.py
+++ b/src/hats_import/catalog/arguments.py
@@ -54,6 +54,8 @@ class ImportArguments(RuntimeArguments):
     """additional keyword arguments to use in creation of rowgroups when writing files to parquet."""
     skymap_alt_orders: list[int] | None = None
     """Additional alternative healpix orders to write a HEALPix skymap."""
+    create_thumbnail: bool = False
+    """Create /dataset/data_thumbnail.parquet from one row of each data partition."""
 
     use_schema_file: str | Path | UPath | None = None
     """path to a parquet file with schema metadata. this will be used for column

--- a/src/hats_import/catalog/run_import.py
+++ b/src/hats_import/catalog/run_import.py
@@ -126,13 +126,16 @@ def run(args, client):
 
     # All done - write out the metadata
     if resume_plan.should_run_finishing:
-        with resume_plan.print_progress(total=5, stage_name="Finishing") as step_progress:
+        with resume_plan.print_progress(total=6, stage_name="Finishing") as step_progress:
             partition_info = PartitionInfo.from_healpix(resume_plan.get_destination_pixels())
             partition_info_file = paths.get_partition_info_pointer(args.catalog_path)
             partition_info.write_to_file(partition_info_file)
+            step_progress.update(1)
             if not args.debug_stats_only:
                 parquet_rows = write_parquet_metadata(
-                    args.catalog_path, create_thumbnail=True, thumbnail_threshold=args.pixel_threshold
+                    args.catalog_path,
+                    create_thumbnail=args.create_thumbnail,
+                    thumbnail_threshold=args.pixel_threshold,
                 )
                 if total_rows > 0 and parquet_rows != total_rows:
                     raise ValueError(

--- a/tests/hats_import/catalog/test_run_import.py
+++ b/tests/hats_import/catalog/test_run_import.py
@@ -257,6 +257,7 @@ def test_dask_runner(
         output_path=tmp_path,
         dask_tmp=tmp_path,
         highest_healpix_order=1,
+        create_thumbnail=True,
         progress_bar=False,
     )
 


### PR DESCRIPTION
While importing DES shape catalog, the finishing step took as long as the rest of the pipeline combined:

```
Planning  : 100%|██████████| 4/4 [00:00<00:00, 781.75it/s]
Mapping   : 100%|██████████| 400/400 [00:29<00:00, 13.46it/s]
Binning   : 100%|██████████| 2/2 [00:57<00:00, 28.54s/it]
Splitting : 100%|██████████| 400/400 [17:03<00:00,  2.56s/it]  
Reducing  : 100%|██████████| 1051/1051 [09:07<00:00,  1.92it/s] 
Finishing : 100%|██████████| 5/5 [25:25<00:00, 305.04s/it]   
```

I believe that most of this is in creating the thumbnail. Since we don't have immediate plans to use this data (and it can be recreated from the catalog at any time), I'm setting the default to not generate the thumbnail just yet.