### PR TITLE
Allow single file for input_file_list

### DIFF
--- a/src/hats_import/runtime_arguments.py
+++ b/src/hats_import/runtime_arguments.py
@@ -6,6 +6,7 @@ import re
 from dataclasses import dataclass
 from importlib.metadata import version
 from pathlib import Path
+import pandas as pd
 
 from hats.catalog import TableProperties
 from hats.io import file_io
@@ -159,9 +160,12 @@ def find_input_paths(input_path="", file_matcher="", input_file_list=None):
             raise ValueError("exactly one of input_path or input_file_list is required")
         input_paths = file_io.find_files_matching_path(input_path, file_matcher)
     elif input_file_list is not None:
-        # It's common for users to accidentally pass in an empty list. Give them a friendly error.
-        if len(input_file_list) == 0:
-            raise ValueError("input_file_list is empty")
+        if pd.api.types.is_list_like(input_file_list):
+            # It's common for users to accidentally pass in an empty list. Give them a friendly error.
+            if len(input_file_list) == 0:
+                raise ValueError("input_file_list is empty")
+        else:
+            input_file_list = [input_file_list]
         input_paths = input_file_list
     else:
         raise ValueError("exactly one of input_path or input_file_list is required")

--- a/tests/hats_import/catalog/test_argument_validation.py
+++ b/tests/hats_import/catalog/test_argument_validation.py
@@ -133,6 +133,16 @@ def test_single_debug_file(formats_headers_csv, tmp_path):
     assert len(args.input_paths) == 1
     assert args.input_paths[0] == formats_headers_csv
 
+    args = ImportArguments(
+        output_artifact_name="catalog",
+        input_file_list=formats_headers_csv,
+        file_reader="csv",
+        output_path=tmp_path,
+        progress_bar=False,
+    )
+    assert len(args.input_paths) == 1
+    assert args.input_paths[0] == formats_headers_csv
+
 
 def test_healpix_args(blank_data_dir, tmp_path):
     """Test errors for healpix partitioning arguments"""


### PR DESCRIPTION
Let users pass in a single file for the `input_file_list` argument, and don't interpret is as a list of single characters.

Closes #580 