### PR TITLE
Add strategic version pinning instructions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,17 +8,3 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    allow:
-      # NOTE: package PINNED at <21.0.0, see https://github.com/astronomy-commons/lsdb/issues/974
-      - dependency-name: "pyarrow"
-        versions: "<21.0.0"
-      # NOTE: package PINNED at <0.3.0, see https://github.com/astronomy-commons/lsdb/issues/1047
-      - dependency-name: "universal-pathlib"
-        versions: "<0.3.0"
-    ignore:
-      # Ignore major updates for pyarrow, see https://github.com/astronomy-commons/lsdb/issues/974
-      - dependency-name: "pyarrow"
-        update-types: ["version-update:semver-major"]
-      # Ignore major updates for universal-pathlib, see https://github.com/astronomy-commons/lsdb/issues/1047
-      - dependency-name: "universal-pathlib"
-        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,17 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    allow:
+      # NOTE: package PINNED at <21.0.0, see https://github.com/astronomy-commons/lsdb/issues/974
+      - dependency-name: "pyarrow"
+        versions: "<21.0.0"
+      # NOTE: package PINNED at <0.3.0, see https://github.com/astronomy-commons/lsdb/issues/1047
+      - dependency-name: "universal-pathlib"
+        versions: "<0.3.0"
+    ignore:
+      # Ignore major updates for pyarrow, see https://github.com/astronomy-commons/lsdb/issues/974
+      - dependency-name: "pyarrow"
+        update-types: ["version-update:semver-major"]
+      # Ignore major updates for universal-pathlib, see https://github.com/astronomy-commons/lsdb/issues/1047
+      - dependency-name: "universal-pathlib"
+        update-types: ["version-update:semver-major"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,15 @@ dependencies = [
     "hats >=0.6.5",
     "numpy>=2.2.0,<3", 
     "pandas>=2.0",
+
+    # NOTE: package PINNED at <21.0.0, see https://github.com/astronomy-commons/lsdb/issues/974
     "pyarrow>=14.0.1,!=19.0.0,<21.0.0; platform_system == 'Windows'",
+
     "pyarrow>=14.0.1,!=19.0.0; platform_system != 'Windows'",
     "tqdm>=4.59.0",
-    "universal-pathlib>=0.2.2",
+
+    # NOTE: package PINNED at <0.3.0, see https://github.com/astronomy-commons/lsdb/issues/1047
+    "universal-pathlib>=0.2.2,<0.3.0",
 ]
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)


### PR DESCRIPTION
## Change Description

Prevent dependabot PRs from regressing due to known version pins.

- [ ] My PR includes a link to the issue that I am addressing



## Solution Description

For specific, strategic version pinning instructions, leave notes to maintainers in the dependency file *and* adjust the `dependabot` configuration with the same notes.


## Code Quality
- [X] I have read the [Contribution Guide](https://hats-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### Build/CI Change Checklist
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the README to reflect this
- [ ] If this is a new CI setup, I have added the associated badge to the README

