### PR TITLE
Require packaging version with `from_parts`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "hats>=0.9.0,<0.10",
     "nested-pandas>=0.6.7,<0.7.0",
     "numpy>=2.2.0,<3", 
+    "packaging>=26.1",
     "pandas>=2.0",
     "tqdm>=4.59.0",
     "universal-pathlib",


### PR DESCRIPTION
## Change Description

`Version.from_parts` was introduced in `packaging==26.1`, and we introduced a call to that method with https://github.com/astronomy-commons/hats-import/pull/682